### PR TITLE
Sunspot testing config by @senen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :test do
   gem 'launchy'
   gem 'selenium-webdriver'
   gem 'simplecov'
+  gem 'sunspot-rails-tester'
 end
 
 group :production do

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -1,6 +1,6 @@
 feature 'Event page' do
 
-  scenario 'visit the event detail page' do
+  scenario 'visit the event detail page', :search do
     event = FactoryGirl.create(:event)
     Event.reindex
     Sunspot.commit
@@ -9,7 +9,7 @@ feature 'Event page' do
     expect(page).to have_content event.title
   end
 
-  scenario 'visit search by keyword and area result page' do
+  scenario 'visit search by keyword and area result page', :search do
     @event = FactoryGirl.create(:event, title: 'New event from Capybara')
     visit root_path
     fill_in :keyword, with: 'Capybara'

--- a/spec/features/visitors/home_page_spec.rb
+++ b/spec/features/visitors/home_page_spec.rb
@@ -1,11 +1,11 @@
 feature 'Home page' do
 
-  scenario 'visit the home page' do
+  scenario 'visit the home page', :search do
     visit root_path
     expect(page).to have_content I18n.t 'main.title'
   end
 
-  scenario 'visit holder agenda page' do
+  scenario 'visit holder agenda page', :search do
     @event = FactoryGirl.create(:event)
     Event.reindex
     Sunspot.commit
@@ -25,7 +25,7 @@ feature 'Home page' do
       Sunspot.commit
     end
 
-    scenario 'in range' do
+    scenario 'in range', :search do
       visit root_path
       fill_in :from, with: Time.now
       fill_in :to, with: Time.now+3.days
@@ -34,7 +34,7 @@ feature 'Home page' do
       expect(page).to have_content "3 Resultados con la palabra XXthreeXX"
     end
 
-    scenario 'in range' do
+    scenario 'in range', :search do
       visit root_path
       fill_in :from, with: Time.now+4.days
       fill_in :to, with: Time.now+5.days
@@ -43,7 +43,7 @@ feature 'Home page' do
       expect(page).to have_content "2 Resultados con la palabra XXthreeXX"
     end
 
-    scenario 'out of range' do
+    scenario 'out of range', :search do
       visit root_path
       fill_in :from, with: Time.now-2.days
       fill_in :to, with: Time.now-1.days
@@ -52,7 +52,7 @@ feature 'Home page' do
       expect(page).to have_content "0 Resultados con la palabra XXthreeXX"
     end
 
-    scenario 'out of range' do
+    scenario 'out of range', :search do
       visit root_path
       fill_in :from, with: Time.now+6.days
       fill_in :to, with: Time.now+7.days
@@ -62,7 +62,7 @@ feature 'Home page' do
     end
   end
 
-  scenario 'visit search by keyword result page' do
+  scenario 'visit search by keyword result page', :search do
     @event = FactoryGirl.create(:event, title: 'New event from Capybara')
     visit root_path
     fill_in :keyword, with: 'Capybara'
@@ -70,7 +70,7 @@ feature 'Home page' do
     expect(page).to have_content @event.title
   end
 
-  scenario 'visit search by keyword and area result page' do
+  scenario 'visit search by keyword and area result page', :search do
     @event = FactoryGirl.create(:event, title: 'New event from Capybara')
     visit root_path
     fill_in :keyword, with: 'Capybara'

--- a/spec/support/sunspot.rb
+++ b/spec/support/sunspot.rb
@@ -1,0 +1,13 @@
+$original_sunspot_session = Sunspot.session
+
+RSpec.configure do |config|
+  config.before do
+    Sunspot.session = Sunspot::Rails::StubSessionProxy.new($original_sunspot_session)
+  end
+
+  config.before :each, :search do
+    Sunspot::Rails::Tester.start_original_sunspot_session
+    Sunspot.session = $original_sunspot_session
+    Sunspot.remove_all!
+  end
+end 


### PR DESCRIPTION
Where
====
Original PR: https://github.com/AyuntamientoMadrid/agendas/pull/1 it was automagitcally closed but some force push to remove files (secrets.yml) that should ever have been present on the git history of this repo. My apologies to anyone else that could have had problems because of it (but you should have cleaned up it before me)

What
====
Developers should not have remember to run solr locally to be able to pass specs.

How
====
Installing sunspot_rails_tester gem to be able to fake solr on testing evironment.

Allow to run solr implicitly on specs with :search metadata defined.
Example:
```
  scenario 'visit search by keyword and area result page', :search do
    @event = FactoryGirl.create(:event, title: 'New event from Capybara')
    visit root_path
    fill_in :keyword, with: 'Capybara'
    select @event.position.area.title, from: :area
    click_button I18n.t('main.form.search')
    expect(page).to have_content @event.title
  end
```