### PR TITLE
Fix Event creation from console

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,8 @@
 class Event < ActiveRecord::Base
   include PublicActivity::Model
 
-  tracked owner: Proc.new { |controller, model| controller.current_user }
-  tracked title: Proc.new { |controller, model| controller.get_title }
+  tracked owner: Proc.new { |controller, model| controller.present? ? controller.current_user : model.user }
+  tracked title: Proc.new { |controller, model| controller.present? ? controller.get_title : model.title }
 
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]


### PR DESCRIPTION
Where & What
=====
Trying out README's instruction to run `rake generator:initialize` or the `rake db:test_seed` task results in a crash:
```
NoMethodError: undefined method `get_title' for nil:NilClass
/Users/bertocq/work/consul/dev/agendas/app/models/event.rb:5:in `block in <class:Event>'
/Users/bertocq/work/consul/dev/agendas/db/test_seeds.rb:35:in `<top (required)>'
/Users/bertocq/work/consul/dev/agendas/lib/tasks/db.rake:4:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:test_seed
(See full trace by running task with --trace)
```
Because of the usage of [public_activity](https://github.com/chaps-io/public_activity) gem, very very badly (assuming there will be always a controller involved in the creation of a Event object) at https://github.com/AyuntamientoMadrid/agendas/blob/master/app/models/event.rb#L4-L5

How
===
Taking values from model instead of from the controller in the scenario where there is no controller involved in the object creation.

Screenshots
===========
No need

Test
====
Run in your console:
```bash
rake generator:initialize
rake db:test_seed
```
See things running as they should

Deployment
==========
No problems related

Warnings
========
I'm creating an spec to test this rake task later on