### PR TITLE
Add new fields to organizations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -468,14 +468,21 @@ Rails/ActionFilter:
 # Cop supports --auto-correct.
 Rails/ApplicationRecord:
   Exclude:
+    - 'app/models/agent.rb'
     - 'app/models/area.rb'
     - 'app/models/attachment.rb'
     - 'app/models/attendee.rb'
+    - 'app/models/category.rb'
     - 'app/models/event.rb'
     - 'app/models/holder.rb'
+    - 'app/models/interest.rb'
+    - 'app/models/legal_representant.rb'
     - 'app/models/manage.rb'
+    - 'app/models/organization.rb'
+    - 'app/models/organization_interest.rb'
     - 'app/models/participant.rb'
     - 'app/models/position.rb'
+    - 'app/models/represented_entity.rb'
     - 'app/models/user.rb'
 
 # Offense count: 3

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.10'
 
 gem 'ancestry', '~> 2.1.0'
 gem 'cancancan', '~> 1.13.1'
-gem 'cocoon',  '~> 1.2.6'
+gem 'cocoon', '~> 1.2.6'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'devise', '~> 3.5', '>= 3.5.10'
 gem 'devise-i18n', '~> 0.12.1'

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ActiveRecord::Base
 
-  has_many :organizations
+  has_many :organizations, dependent: :destroy
 
 end

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -1,6 +1,6 @@
 class Interest < ActiveRecord::Base
 
-  has_many :organization_interests
+  has_many :organization_interests, dependent: :destroy
   has_many :organizations, through: :organization_interest
 
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,18 +4,18 @@ class Organization < ActiveRecord::Base
   enum range_fund: [:range_1, :range_2, :range_3, :range_4]
   enum entity_type: [:association, :federation, :lobby]
 
-  validates_uniqueness_of :inscription_reference, allow_blank: true, allow_nil: true 
+  validates :inscription_reference, uniqueness: true, allow_blank: true, allow_nil: true
 
-  has_many :represented_entities
-  has_many :agents
-  has_many :organization_interests
-  has_many :interests, through: :organization_interests
-  has_many :subventions
-  has_many :contracts
-  has_many :funds
-  has_one :comunication_representant
-  has_one :user
-  has_one :legal_representant
+  has_many :represented_entities, dependent: :destroy
+  has_many :agents, dependent: :destroy
+  has_many :organization_interests, dependent: :destroy
+  has_many :interests, through: :organization_interests, dependent: :destroy
+  has_many :subventions, dependent: :destroy
+  has_many :contracts, dependent: :destroy
+  has_many :funds, dependent: :destroy
+  has_one :comunication_representant, dependent: :destroy
+  has_one :user, dependent: :destroy
+  has_one :legal_representant, dependent: :destroy
   belongs_to :category
 
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,6 +2,9 @@ class Organization < ActiveRecord::Base
 
   enum registered_lobbies: [:generalitat_catalunya, :cnmc, :europe_union, :others]
   enum range_fund: [:range_1, :range_2, :range_3, :range_4]
+  enum entity_type: [:association, :federation, :lobby]
+
+  validates_uniqueness_of :inscription_reference, allow_blank: true, allow_nil: true 
 
   has_many :represented_entities
   has_many :agents

--- a/db/migrate/20171122161940_add_new_fields_to_organizations.rb
+++ b/db/migrate/20171122161940_add_new_fields_to_organizations.rb
@@ -1,0 +1,12 @@
+class AddNewFieldsToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :inscription_reference, :string
+    add_column :organizations, :inscription_date, :date
+    add_column :organizations, :entity_type, :string
+    add_column :organizations, :neighbourhood, :string
+    add_column :organizations, :district, :string
+    add_column :organizations, :scope, :string
+    add_column :organizations, :associations_count, :integer
+    add_column :organizations, :members_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120210302) do
+ActiveRecord::Schema.define(version: 20171122161940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,8 +196,16 @@ ActiveRecord::Schema.define(version: 20171120210302) do
     t.boolean  "contract"
     t.boolean  "denied_public_data"
     t.boolean  "denied_public_events"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.string   "inscription_reference"
+    t.date     "inscription_date"
+    t.string   "entity_type"
+    t.string   "neighbourhood"
+    t.string   "district"
+    t.string   "scope"
+    t.integer  "associations_count"
+    t.integer  "members_count"
   end
 
   add_index "organizations", ["category_id"], name: "index_organizations_on_category_id", using: :btree

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
     denied_public_data false
     denied_public_events false
     entity_type :lobby
-    
+
     trait :company do
       name { Faker::Company.name }
     end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -24,9 +24,22 @@ FactoryGirl.define do
     contract true
     denied_public_data false
     denied_public_events false
-
+    entity_type :lobby
+    
     trait :company do
       name { Faker::Company.name }
+    end
+
+    trait :lobby do
+      entity_type :lobby
+    end
+
+    trait :association do
+      entity_type :association
+    end
+
+    trait :federation do
+      entity_type :federation
     end
 
     trait :person  do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -4,8 +4,29 @@ describe Organization do
 
   let(:organization) { build(:organization) }
 
+  it { should respond_to(:generalitat_catalunya?) }
+  it { should respond_to(:cnmc?) }
+  it { should respond_to(:europe_union?) }
+  it { should respond_to(:others?) }
+
+  it { should respond_to(:range_1?) }
+  it { should respond_to(:range_2?) }
+  it { should respond_to(:range_3?) }
+  it { should respond_to(:range_4?) }
+
+  it { should respond_to(:federation?) }
+  it { should respond_to(:association?) }
+  it { should respond_to(:lobby?) }
+
   it "should be valid" do
     expect(organization).to be_valid
+  end
+
+  it "should not be valid when inscription_reference already exists" do
+    organization = create(:organization, inscription_reference: "XYZ")
+    another_organization = build(:organization, inscription_reference: "XYZ")
+
+    expect(another_organization).not_to be_valid
   end
 
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -23,7 +23,7 @@ describe Organization do
   end
 
   it "should not be valid when inscription_reference already exists" do
-    organization = create(:organization, inscription_reference: "XYZ")
+    create(:organization, inscription_reference: "XYZ")
     another_organization = build(:organization, inscription_reference: "XYZ")
 
     expect(another_organization).not_to be_valid


### PR DESCRIPTION
Where
=====
* **Related Issue:** #52 

What
====
We need to create some new fields at Organizations table to be able to store some remote CSV information

These new fields are:

* inscription_reference:string
  This is the unique identifier for associations and federations at CSV files, so we will need to use this   field on daily updates at importation process. 
* inscription_date:date (Maybe src dates will be well formatted 🙏 )
  This is the inscription date of association or federation. I colud be useful on importation update record process.
* entity_type: enum [:association | :federation]
* neighbourhood: string (Only for imported associations)
* district: string (Only for imported associations)
* scope: string
* associations_count:integer (Only for imported associations)
* members_count: integer (Only for imported federations)

How
===
Create a migration with new fields and updating schema.

Notes and Warnings
===============
These fields should be shown only at organizarion public page where they are present. The only way to set these fields in through importation process (Our application does not allow to edit these fields)