### PR TITLE
Revert sunspot solr update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
       nokogiri
       rails (>= 3)
       sunspot (= 2.2.7)
-    sunspot_solr (2.2.7)
+    sunspot_solr (2.2.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thin (1.7.2)


### PR DESCRIPTION
Where
=====
* **Related PR's:** #43

What
====
This reverts commit 296a57f5d65a77d1ed16cea4611f21f02bfd335f, reversing
changes made to f618db3010007cab8c8ec10d91aeeeebb7834686.

This update breaks public events index locally and we do not have time to check and to solve problems with newest version! 

How
===
Reverting depfu PR

Warnings
=======
We have to merge very carefully depfu updates because we dont have enough specs to rely on.