### PR TITLE
Admin organizations index

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -6,37 +6,38 @@ module Admin
     def index
       @organizations = Organization.all.page(params[:page]).per(25)
     end
-  end
 
-  def create
-    @organization = Organization.new(organization_params)
-    if @organization.save
-      redirect_to admin_organizations_path, notice: t('backend.successfully_created_record')
-    else
-      flash[:alert] = t('backend.review_errors')
-      render :new
+    def create
+      @organization = Organization.new(organization_params)
+      if @organization.save
+        redirect_to admin_organizations_path, notice: t('backend.successfully_created_record')
+      else
+        flash[:alert] = t('backend.review_errors')
+        render :new
+      end
     end
-  end
 
-  def new
-    @organization = Organization.new
-    @organization.user = User.new
-  end
+    def new
+      @organization = Organization.new
+      @organization.user = User.new
+    end
 
 
-  private
+    private
 
-  def organization_params
-    params.require(:organization)
-          .permit(:reference, :identifier, :name, :first_name, :last_name, :phones, :email,
-                  :web, :address_type, :address, :number, :gateway, :stairs, :floor, :door,
-                  :postal_code, :town, :province, :description, :registered_lobbies, :category_id,
-                  :fiscal_year, :range_fund, :subvention, :contract, :denied_public_data, :denied_public_events, interest_ids: [],
-                  legal_representant_attributes: [:id, :identifier, :name, :first_name, :last_name, :phones, :email],
-                  user_attributes: [:id, :first_name, :last_name, :role, :email, :active, :phones, :password, :password_confirmation],
-                  represented_entities_attributes: [:id, :identifier, :name, :first_name, :last_name, :from, :fiscal_year, :range_fund, :subvention, :contract],
-                  organization_interests_attributes: [:interest_ids],
-                  agents_attributes: [:id, :identifier, :name, :first_name, :last_name, :from, :to, :public_assignments])
-  end
+    def organization_params
+      params.require(:organization)
+            .permit(:reference, :identifier, :name, :first_name, :last_name, :phones, :email,
+                    :web, :address_type, :address, :number, :gateway, :stairs, :floor, :door,
+                    :postal_code, :town, :province, :description, :registered_lobbies, :category_id,
+                    :fiscal_year, :range_fund, :subvention, :contract, :denied_public_data, :denied_public_events, interest_ids: [],
+                    legal_representant_attributes: [:id, :identifier, :name, :first_name, :last_name, :phones, :email],
+                    user_attributes: [:id, :first_name, :last_name, :role, :email, :active, :phones, :password, :password_confirmation],
+                    represented_entities_attributes: [:id, :identifier, :name, :first_name, :last_name, :from, :fiscal_year, :range_fund, :subvention, :contract],
+                    organization_interests_attributes: [:interest_ids],
+                    agents_attributes: [:id, :identifier, :name, :first_name, :last_name, :from, :to, :public_assignments])
+    end
+
+  end  
 
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,9 +1,11 @@
-class Admin::OrganizationsController < AdminController
+module Admin
+  class OrganizationsController < AdminController
 
-  load_and_authorize_resource
+    load_and_authorize_resource
 
-  def index
-    @organizations = Organization.all.page(params[:page]).per(25)
+    def index
+      @organizations = Organization.all.page(params[:page]).per(25)
+    end
   end
 
   def create

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -3,6 +3,7 @@ class Admin::OrganizationsController < AdminController
   load_and_authorize_resource
 
   def index
+    @organizations = Organization.all.page(params[:page]).per(25)
   end
 
   def create

--- a/app/helpers/admin/organizations_helper.rb
+++ b/app/helpers/admin/organizations_helper.rb
@@ -1,0 +1,7 @@
+module Admin::OrganizationsHelper
+
+  def total_organizations
+    Organization.count
+  end
+
+end

--- a/app/helpers/admin/organizations_helper.rb
+++ b/app/helpers/admin/organizations_helper.rb
@@ -1,7 +1,7 @@
-module Admin::OrganizationsHelper
-
-  def total_organizations
-    Organization.count
+module Admin
+  module OrganizationsHelper
+    def total_organizations
+      Organization.count
+    end
   end
-
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,7 @@ class Ability
         can :manage, Event
         can :index, Area
         can [:index, :show], Holder
+        can :manage, Organization
       else
         can :manage, :all
       end

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -1,1 +1,41 @@
-<%= link_to "Nueva organización", new_admin_organization_path if can? :create, Organization %>
+<h1>
+  <%= t('backend.companies') %> (<%= total_organizations %>)
+  <%= link_to t('backend.new_company'), new_admin_organization_path, :class => "button radius warning right" if can? :create, Organization %>
+</h1>
+
+  <%= paginate @organizations %>
+<div class="row">
+  <table class="event">
+    <thead>
+      <tr>
+        <th><%= t('backend.title')%></th>
+        <th class="right"><%= t('backend.actions')%></th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <th><%= t('backend.title')%></th>
+        <th class="right"><%= t('backend.actions')%></th>
+      </tr>
+    </tfoot>
+    <tbody>
+      <% @organizations.each do |organization| %>
+      <tr>
+        <td>
+          <%= organization.name %>
+        </td>
+        <td class="right">
+          <%= link_to edit_admin_organization_path(organization), title: t('backend.edit') do %>
+            <i class="step fi-page-edit size-24"></i>
+          <% end if can? :edit, organization %>
+
+          <%= link_to admin_organization_path(organization), method: :delete, data: { confirm: t("backend.delete_confirm") }, title: t('backend.delete') do%>
+            <i class="step fi-page-delete size-24"></i>
+          <% end if can? :destroy, organization %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<%= paginate @organizations%>

--- a/app/views/layouts/_admin_sidebar.html.erb
+++ b/app/views/layouts/_admin_sidebar.html.erb
@@ -18,7 +18,7 @@
     <% if current_user.admin? %>
     <li class="<%= active_menu('admin/organizations') %>">
       <a href="<%= admin_organizations_path %>">
-        <i class="fi-calendar size-18"> Organizaciones</i>
+        <i class="fi-book size-18"> <%= t("backend.companies")%></i>
       </a>
     </li>
     <% end %>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -91,6 +91,8 @@ es:
     file: "Archivo"
     title: "Título"
     company: "Organización"
+    companies: "Organizaciones"
+    new_company: "Nueva organización"
     description: "Descripción"
     new_event: "Nuevo evento"
     edit_event: "Editar evento"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -91,6 +91,8 @@ es:
     file: "Archivo"
     title: "Título"
     company: "Organización"
+    companies: "Organizaciones"
+    new_company: "Nueva organización"
     description: "Descripción"
     new_event: "Nuevo evento"
     edit_event: "Editar evento"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   resources :activities
 
   namespace :admin do
-    resources :organizations, only: [:new, :create, :index]
+    resources :organizations
   end
 
 end

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1,0 +1,25 @@
+feature 'Organization' do
+
+  describe 'User admin' do
+    background do
+      user_admin = create(:user, :admin)
+      signin(user_admin.email, user_admin.password)
+    end
+
+    describe "Index" do
+      background do
+        3.times { create(:organization) }
+      end
+
+      scenario 'visit admin page and organization button render organization index' do
+        visit admin_path
+
+        click_link "Organizaciones"
+
+        expect(page).to have_content "Nueva organización"
+        expect(page).to have_content "#{I18n.t 'backend.companies'} (3)"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #28 

What
====
Add organizations index (views and controllers) for admins.

How
===
- Create the corresponding controller (with actions) and views.
- Add a link to the admins sidebar to access the index.
- Added CanCanCan abilites to avoid non-admin users access that page.

Screenshots
===========
![organization_index](https://user-images.githubusercontent.com/31625251/33180350-ae1aaa34-d06c-11e7-8af1-7c8e41b15fe6.png)

Test
====
Added test for organizations index.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.