### PR TITLE
Organization interests seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,32 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+# Categories
+interests = ['Actividad económica y empresarial',
+             'Actividad normativa y de regulación',
+             'Administración de personal y recursos humanos',
+             'Administración electrónica',
+             'Administración económica, financiera y tributaria de la Ciudad',
+             'Atención a la ciudadanía',
+             'Comercio',
+             'Consumo',
+             'Cultura (bibliotecas, archivos, museos, patrimonio histórico artístico, etc.)',
+             'Deportes',
+             'Desarrollo tecnológico',
+             'Educación y Juventud',
+             'Emergencias y seguridad',
+             'Empleo',
+             'Medio Ambiente',
+             'Medios de comunicación',
+             'Movilidad, transporte y aparcamientos',
+             'Salud',
+             'Servicios sociales',
+             'Transparencia y participación ciudadana',
+             'Turismo',
+             'Urbanismo',
+             'Vivienda']
+
+interests.each do |name|
+  Interest.create(name: name)
+end

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -106,11 +106,10 @@ interest_21 = Interest.create(name:"Turismo")
 interest_22 = Interest.create(name:"Urbanismo")
 interest_23 = Interest.create(name:"Vivienda")
 
-#Cateogry
+#Category
 category_1 = Category.create(name: 'Empresas')
 category_2 = Category.create(name: 'Asociaciones')
 category_3 = Category.create(name: 'Comunidad de Bienes')
-
 
 # Organization
 user_lobby_1 = User.create(password: '12345678', email: Faker::Internet.email, first_name: 'Pepe', last_name: 'Perez', active: 1)

--- a/lib/tasks/organizations.rake
+++ b/lib/tasks/organizations.rake
@@ -1,0 +1,32 @@
+namespace :organizations do
+  task :add_organization_interests => :environment do
+    interests = ['Actividad económica y empresarial',
+                 'Actividad normativa y de regulación',
+                 'Administración de personal y recursos humanos',
+                 'Administración electrónica',
+                 'Administración económica, financiera y tributaria de la Ciudad',
+                 'Atención a la ciudadanía',
+                 'Comercio',
+                 'Consumo',
+                 'Cultura (bibliotecas, archivos, museos, patrimonio histórico artístico, etc.)',
+                 'Deportes',
+                 'Desarrollo tecnológico',
+                 'Educación y Juventud',
+                 'Emergencias y seguridad',
+                 'Empleo',
+                 'Medio Ambiente',
+                 'Medios de comunicación',
+                 'Movilidad, transporte y aparcamientos',
+                 'Salud',
+                 'Servicios sociales',
+                 'Transparencia y participación ciudadana',
+                 'Turismo',
+                 'Urbanismo',
+                 'Vivienda']
+
+    interests.each do |name|
+      Interest.find_or_create_by(name: name)
+    end
+
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #73

What
====
Create seeds to insert organization interests into DB.

How
===
I created seeds for fresh installs and a rake task for the production website, like in #80.

Screenshots
===========
There aren't.

Test
====
Not needed.

Deployment
==========
run rake task: ` rake organizations:add_organization_interests` in order to insert the categories.

Warnings
========
Nothing to apply.
