### PR TITLE
Add export link to organizations index

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -22,6 +22,6 @@ class OrganizationsController < ApplicationController
 
     def set_organization
       @organization = Organization.find(params[:id])
-    end    
+    end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,8 +43,7 @@ module ApplicationHelper
 
   def export_link(url)
     link_to url, class: "right dib dn hide-for-small-only" do
-      content_tag(:span, "", class: "icon icon__export") +
-      t('main.export')
+      content_tag(:span, "", class: "icon icon__export") + t('main.export')
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,11 @@ module ApplicationHelper
     end
   end
 
+  def export_link(url)
+    link_to url, class: "right dib dn hide-for-small-only" do
+      content_tag(:span, "", class: "icon icon__export") +
+      t('main.export')
+    end
+  end
+
 end

--- a/app/views/organizations/index.csv.erb
+++ b/app/views/organizations/index.csv.erb
@@ -1,0 +1,11 @@
+<%=
+  exporter = PublicOrganizationExporter.new
+
+  CSV.generate(col_sep: ';', force_quotes: true, encoding: "iso-8859-1") do |csv|
+    csv << exporter.windows_headers
+
+    @organizations.results.each do |organization|
+      csv << exporter.windows_organization_row(organization)
+    end
+  end.html_safe
+%>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -15,6 +15,10 @@
                  keyword: params[:keyword] %>
     <% end %>
 
+    <div class="tools">
+      <%= export_link(current_url(format: :csv)) %>
+    </div>
+
     <div class="row">
       <div class="small-12 columns mb10">
         <p><strong class="result-l mb20"><%= oganizations_index_subtitle %></strong></p>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -16,8 +16,8 @@
 
     <div class="tools">
       <%= t('main.get_updates')%><a href="<%= current_url(:format=>:atom)%>"><span class="icon icon__feed"></span> feed</a>
-      <a class="right dib dn hide-for-small-only" href="<%= current_url(:format=>:csv)%>"><span class="icon icon__export"></span> <%= t('main.export')%></a>
-    </div><!-- .tools -->
+      <%= export_link(current_url(format: :csv)) %>
+    </div>
 
     <div class="row">
       <div class="small-8 columns mb20">

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -158,6 +158,31 @@ feature 'Organizations page' do
 
       expect(page).to have_content organization.name
     end
+
+    describe "Export link" do
+      scenario "Should generate CSV file with organizations" do
+        visit organizations_path
+
+        click_link "Exportar"
+
+        expect(page.status_code).to eq 200
+        expect(page.response_headers['Content-Type']).to eq "text/csv; charset=utf-8"
+      end
+
+      scenario "Should include only search results", :search do
+        organizations = create_list(:organization, 2)
+        Organization.reindex
+        visit organizations_path
+        fill_in :keyword, with: organizations.first.name
+        click_on "Buscar"
+
+        click_link "Exportar"
+
+        expect(page).to have_content organizations.first.name
+        expect(page).not_to have_content organizations.last.name
+      end
+    end
+
   end
 
   describe "Show" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #37
* **Related PR:** #74 

What
====
Allo any user to exportation organizations index results.

How
===
Adding new link "Export"
Generating organizations CSV file with new index.csv.erb view and using PublicOrganizationExport class.

Screenshots
=========
![captura de pantalla 2017-11-25 a las 16 01 34](https://user-images.githubusercontent.com/15726/33231706-08302d44-d1fa-11e7-9632-34bb18a6f58a.png)

