### PR TITLE
Allow admins to reset other users's passwords

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,8 @@ class UsersController < AdminController
   end
 
   def update
+    remove_password_params if params[:user][:password].blank?
+
     if @user.update_attributes(user_params)
       redirect_to users_path, notice: t('backend.successfully_updated_record')
     else
@@ -62,11 +64,18 @@ class UsersController < AdminController
   end
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :role, :id, manages_attributes: [:id, :holder_id, :_destroy])
+    params.require(:user).permit(:first_name, :last_name, :email,
+                                 :password, :password_confirmation,
+                                 :role, :id, manages_attributes: [:id, :holder_id, :_destroy])
   end
 
   def load_holders
     @holders = Holder.all.order("last_name asc")
+  end
+
+  def remove_password_params
+    params[:user].delete(:password)
+    params[:user].delete(:password_confirmation)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,10 @@ class User < ActiveRecord::Base
   belongs_to :organization
 
   validates :first_name, :last_name, :email, presence: true
+  validates :password, presence: true,
+                       if: :encrypted_password_changed?,
+                       on: :update
+
   validate :manages_uniqueness
 
   accepts_nested_attributes_for :manages, reject_if: :all_blank, allow_destroy: true

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,47 +1,62 @@
-<%= link_to t('backend.back'), users_path , :class=> "button tiny radius" %>
-<%= form_for @user, html: {class: 'admin-form'} do |f| %>
+<%= link_to t("backend.back"), users_path, class: "button tiny radius" %>
+<%= form_for @user, html: { class: 'admin-form' } do |f| %>
 
-    <% if @user.errors.any? %>
-        <div class="panel callout radius">
-          <strong><%= t('activerecord.errors.template.header',
-  :model => User.model_name.human, :count => @user.errors.count) %></strong>
-          <ul>
-            <% @user.errors.full_messages.each do |msg| %>
-                <li><%= msg %></li>
-            <% end %>
-          </ul>
-        </div>
-    <% end %>
-
-    <fieldset>
-      <legend><%= t('backend.basic_data') %></legend>
-      <%= f.label :first_name, t('backend.first_name') %>
-      <%= f.text_field :first_name, readonly: Rails.application.secrets.madrid %>
-      <%= f.label :last_name, t('backend.last_name') %>
-      <%= f.text_field :last_name, readonly: Rails.application.secrets.madrid %>
-      <%= f.label :email, t('backend.email') %>
-      <%= f.text_field :email, readonly: Rails.application.secrets.madrid %>
-      <% unless Rails.application.secrets.madrid %>
-      <%= f.label :role, t('backend.role') %>
-      <%= f.select :role, [[t('backend.user'), :user],[t('backend.admin'), :admin]] %>
-      <% end %>
-    </fieldset>
-
-    <fieldset>
-      <legend><%= t('backend.positions') %></legend>
-      <div class="row">
-        <div class="small-2 columns"></div>
-        <div class="small-8 columns"></div>
-        <div class="small-2 columns"></div>
-      </div>
-      <div id="manages">
-        <%= f.fields_for :manages do |manage| %>
-            <%= render 'manage_fields', f: manage %>
+  <% if @user.errors.any? %>
+    <div class="panel callout radius">
+    <strong><%= t("activerecord.errors.template.header",
+                model: User.model_name.human,
+                count: @user.errors.count) %></strong>
+      <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
         <% end %>
-      </div>
-      <%= link_to_add_association t('backend.add'), f, :manages, :class => "button radius tiny info right",'data-association-insertion-method' => 'append', 'data-association-insertion-node' => '#manages' %>
+      </ul>
+    </div>
+  <% end %>
+
+  <fieldset>
+    <legend><%= t("backend.basic_data") %></legend>
+    <%= f.label :first_name, t("backend.first_name") %>
+    <%= f.text_field :first_name, readonly: Rails.application.secrets.madrid %>
+    <%= f.label :last_name, t("backend.last_name") %>
+    <%= f.text_field :last_name, readonly: Rails.application.secrets.madrid %>
+    <%= f.label :email, t("backend.email") %>
+    <%= f.text_field :email, readonly: Rails.application.secrets.madrid %>
+    <% unless Rails.application.secrets.madrid %>
+      <%= f.label :role, t("backend.role") %>
+      <%= f.select :role, [[t("backend.user"), :user], [t("backend.admin"), :admin]] %>
+    <% end %>
+  </fieldset>
+
+  <fieldset>
+    <legend><%= t("backend.positions") %></legend>
+    <div class="row">
+      <div class="small-2 columns"></div>
+      <div class="small-8 columns"></div>
+      <div class="small-2 columns"></div>
+    </div>
+    <div id="manages">
+      <%= f.fields_for :manages do |manage| %>
+        <%= render "manage_fields", f: manage %>
+      <% end %>
+    </div>
+    <%= link_to_add_association t("backend.add"), f, :manages,
+                                class: "button radius tiny info right",
+                                "data-association-insertion-method" => "append",
+                                "data-association-insertion-node" => "#manages" %>
+  </fieldset>
+
+  <% if action_name == "edit" || action_name == "update" %>
+    <fieldset>
+      <legend><%= t("backend.change_password") %></legend>
+      <%= f.label :password, t("backend.new_password") %>
+      <%= f.password_field :password %>
+      <%= f.label :password_confirmation, t("backend.new_password_confirmation") %>
+      <%= f.password_field :password_confirmation %>
     </fieldset>
-    <%= submit_tag t('backend.save'), :class=> "button radius success right" %>
+  <% end %>
+
+  <%= submit_tag t("backend.save"), class: "button radius success right" %>
 <% end %>
 
-<%= javascript_include_tag 'users'%>
+<%= javascript_include_tag "users" %>

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -52,3 +52,4 @@ es:
         identifier: "Agente: Identificador"
         name: "Agente: Nombre"
         from: "Agente: Fecha de inicio"
+

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -15,6 +15,7 @@ es:
     none: "Ninguno"
     frontend: "Zona pública"
     basic_data: "Datos"
+    change_password: "Cambiar contraseña"
     mandatory_field: "Este campo es obligatorio"
     successfully_updated_record: "Registro actualizado correctamente"
     successfully_destroyed_record: "Registro eliminado correctamente"

--- a/spec/features/admin/passwords_specs.rb
+++ b/spec/features/admin/passwords_specs.rb
@@ -1,9 +1,11 @@
 shared_examples "password editable" do |trait|
-  scenario "#{trait} user can change their own account password" do
+  background do
     user = create(:user, trait.to_sym)
-    login_as user
+    login_as(user)
     visit edit_password_path
+  end
 
+  scenario "#{trait} user can change their own account password" do
     fill_in 'user_password', with: '123456789'
     fill_in 'user_password_confirmation', with: '123456789'
     click_button I18n.t 'backend.save'
@@ -12,10 +14,6 @@ shared_examples "password editable" do |trait|
   end
 
   scenario "Should show error when passwords are not equal" do
-    user = create(:user, trait.to_sym)
-    login_as user
-    visit edit_password_path
-
     fill_in 'user_password', with: '123456789'
     fill_in 'user_password_confirmation', with: '12345678'
     click_button I18n.t 'backend.save'
@@ -34,6 +32,38 @@ feature 'Passwords' do
     visit edit_password_path
 
     expect(page).to have_content "Necesitas iniciar sesión o registrarte para continuar. "
+  end
+
+  context 'Admin' do
+    background do
+      admin = create(:user, :admin)
+      user  = create(:user, password: 'password')
+      login_as(admin, scope: :user)
+      visit edit_user_path(user)
+    end
+
+    it "can reset any user's password" do
+      fill_in :user_password, with: 'new_password'
+      fill_in :user_password_confirmation, with: 'new_password'
+      click_button(I18n.t('backend.save'))
+
+      expect(page).to have_content(I18n.t('backend.successfully_updated_record'))
+    end
+
+    it "can update an user's information without updating the password" do
+      fill_in :user_email, with: 'example@mail.com'
+      click_button(I18n.t('backend.save'))
+
+      expect(page).to have_content(I18n.t('backend.successfully_updated_record'))
+    end
+
+    it "can't reset an user's password if the params don't match" do
+      fill_in :user_password, with: 'new_password'
+      fill_in :user_password_confirmation, with: 'no_match'
+      click_button(I18n.t('backend.save'))
+
+      expect(page).to have_content('Confirmación de la contraseña no coincide')
+    end
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #33

What
====
* Allow admins to reset an user's password

How
===
* Modified related MVCs accordingly to allow the new feature
* Refactored related spec to make it more DRY

Screenshots
===========
![screenshot-2017-11-27 admin](https://user-images.githubusercontent.com/9470839/33284297-f72391bc-d384-11e7-9126-1595fe61123f.png)

Test
====
* Increased coverage for three (3) scenarios
