### PR TITLE
Organization user event new

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,8 @@ class Ability
         can :manage, :all
       end
       can :index, :activities
+    elsif user.lobby?
+      can [:index, :new, :create], Event
     else
       if Holder.managed_by(user.id).any?
         can :manage, Event, id: Event.ability_titular_events(user)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,8 @@ class Event < ActiveRecord::Base
   validates :title, :position, :scheduled, presence: true
   validate :participants_uniqueness, :position_not_in_participants
 
+  before_create :set_status
+
   belongs_to :user
   belongs_to :position
   has_many :participants, dependent: :destroy
@@ -127,5 +129,9 @@ class Event < ActiveRecord::Base
       positions_ids = participants.collect{|p| p.position.id }
       return unless position && positions_ids.include?(position.id)
       errors.add(:base, I18n.t('backend.position_not_in_participants'))
+    end
+
+    def set_status
+      self.status = :on_request if self.user.lobby?
     end
 end

--- a/db/migrate/20171128143359_add_status_to_events.rb
+++ b/db/migrate/20171128143359_add_status_to_events.rb
@@ -1,0 +1,5 @@
+class AddStatusToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 20171129121738) do
     t.integer  "position_id"
     t.string   "location"
     t.string   "slug"
+    t.string   "status"
   end
 
   add_index "events", ["position_id"], name: "index_events_on_position_id", using: :btree

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -82,4 +82,38 @@ feature 'Events' do
     end
 
   end
+
+  describe 'Organization user' do
+    background do
+      organization_user = create(:user, :lobby)
+      @position = create(:position)
+      organization_user.manages.create(holder_id: @position.holder_id)
+      signin(organization_user.email, organization_user.password)
+    end
+
+    scenario 'visit index event page' do
+      event = create(:event, title: 'New event for lobbies', position: @position)
+      visit events_path
+
+      expect(page).to have_content event.title
+    end
+
+    scenario 'create new event' do
+      event = create(:event, title: 'Event not for lobbies')
+      visit events_path
+
+      click_link I18n.t('backend.new_event')
+
+      expect(page).to have_content I18n.t('backend.new_event')
+
+      fill_in :event_title, with: 'New event for a lobby'
+      fill_in :event_scheduled, with: '02/11/2017 06:30'
+
+      click_button I18n.t('backend.save')
+
+      expect(page).to have_content 'New event for a lobby'
+      expect(page).to_not have_content event.title
+    end
+
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -157,4 +157,30 @@ describe Event do
 
   end
 
+  describe "organizations' events" do
+    let!(:organization_user) { create(:user, :lobby) }
+    let!(:position) { create(:position) }
+
+    it "should create event with status on_request" do
+      event = create(:event, title: 'Event on request', user: organization_user)
+      event.save
+
+      expect(event.status).to eq('on_request')
+    end
+
+  end
+
+  describe "admins' events" do
+    let!(:organization_user) { create(:user, :admin) }
+    let!(:position) { create(:position) }
+
+    it "should create event with status nil" do
+      event = create(:event, title: 'Admin event', user: organization_user)
+      event.save
+
+      expect(event.status).to eq(nil)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #19

What
====
Let the organization users create new events with status on_request

How
===
- Add a column to the events table called status.
- The status is given with a `before_create` callback, so that each time an event is created, no matter the place, the status is set if the user is from an organization.
- Enable the permissions for organization users to create events in 'ability.rb'.

Screenshots
===========
![events01](https://user-images.githubusercontent.com/31625251/33380553-c9a3686e-d51b-11e7-9cbd-a783164f4d68.png)

![events02](https://user-images.githubusercontent.com/31625251/33380560-ce81afa8-d51b-11e7-8523-5299afbecc2b.png)

![events03](https://user-images.githubusercontent.com/31625251/33380565-d31bc12a-d51b-11e7-96d3-a861979dc139.png)

Test
====
- Test for the organizations feature (access to events index and create new event).
- Test for the `before_create` callback (set the status for the event).

Deployment
==========
Run migrations.

Warnings
========
Nothing.
