### PR TITLE
Event field status to enum

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,6 +42,8 @@ class Event < ActiveRecord::Base
     joins(:position).where("positions.holder_id IN (?)", holder_ids)
   }
 
+  enum status: { requested: 0, accepted: 1 }
+
   def self.managed_by(user)
     holder_ids = Holder.managed_by(user.id).pluck(:id)
     titular_event_ids = Event.by_holders(holder_ids).pluck(:id)
@@ -139,7 +141,7 @@ class Event < ActiveRecord::Base
     end
 
     def set_status
-      self.status = :on_request if self.user.lobby?
+      self.status = "requested" if self.user.lobby?
     end
 
     def role_validate_published_at

--- a/db/migrate/20171204113941_change_event_status_type.rb
+++ b/db/migrate/20171204113941_change_event_status_type.rb
@@ -1,0 +1,5 @@
+class ChangeEventStatusType < ActiveRecord::Migration
+  def change
+    change_column :events, :status, 'integer USING CAST(status AS integer)', default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171203204027) do
+ActiveRecord::Schema.define(version: 20171204113941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,12 +112,12 @@ ActiveRecord::Schema.define(version: 20171203204027) do
     t.text     "description"
     t.datetime "scheduled"
     t.integer  "user_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.integer  "position_id"
     t.string   "location"
     t.string   "slug"
-    t.string   "status"
+    t.integer  "status",            default: 0
     t.boolean  "lobby_activity"
     t.text     "notes"
     t.string   "reasons"

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -177,26 +177,12 @@ describe Event do
 
   describe "organizations' events" do
     let!(:organization_user) { create(:user, :lobby) }
-    let!(:position) { create(:position) }
 
     it "should create event with status on_request" do
       event = create(:event, title: 'Event on request', user: organization_user)
       event.save
 
-      expect(event.status).to eq('on_request')
-    end
-
-  end
-
-  describe "admins' events" do
-    let!(:organization_user) { create(:user, :admin) }
-    let!(:position) { create(:position) }
-
-    it "should create event with status nil" do
-      event = create(:event, title: 'Admin event', user: organization_user)
-      event.save
-
-      expect(event.status).to eq(nil)
+      expect(event.status).to eq('requested')
     end
 
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #115 
* **Related PR's:** #95 

What
====
Fix the enum problem that was not merge in the previous PR.

How
===
Changed the column type string to integer and added an enum to set the status.

Screenshots
===========
There aren't.

Test
====
The test to check the status after create has been updated with the new enum.

Deployment
==========
There is a new migration to change the column.

Warnings
========
Nothing.
