### PR TITLE
Organization user can edit events on request

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,7 @@ class Ability
       can :index, :activities
     elsif user.lobby?
       can [:index, :new, :create, :show], Event
-      can [:edit, :update], Event, status: "requested", user_id: user.id
+      can [:edit, :update], Event, status: "requested"
     else
       if Holder.managed_by(user.id).any?
         can :manage, Event, id: Event.ability_titular_events(user)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,7 +17,8 @@ class Ability
       end
       can :index, :activities
     elsif user.lobby?
-      can [:index, :new, :create], Event
+      can [:index, :new, :create, :show], Event
+      can [:edit, :update], Event, status: "requested", user_id: user.id
     else
       if Holder.managed_by(user.id).any?
         can :manage, Event, id: Event.ability_titular_events(user)

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -592,10 +592,34 @@ feature 'Events' do
 
         visit events_path
 
-        puts page.body
+        expect(page).to have_link("", href: edit_event_path(event_requested).to_s)
+        expect(page).to_not have_link("", href: edit_event_path(event_accepted).to_s)
+      end
 
-        expect(page).to have_content edit_event_path(event_requested)
-        expect(page).to_not have_content edit_event_path(event_accepted)
+      scenario "Edit buttons enabled for events on_request on show view" do
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
+        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1)
+
+        visit event_path(event_requested)
+
+        expect(page).to have_link("Editar")
+
+        visit event_path(event_accepted)
+
+        expect(page).to_not have_link("Editar")
+      end
+
+      scenario "User can edit events" do
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
+
+        visit event_path(event_requested)
+
+        click_link "Editar"
+
+        fill_in :event_title, with: "Edited event title"
+        click_button "Guardar"
+
+        expect(page).to have_content "Edited event title"
       end
     end
 

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -146,14 +146,14 @@ feature 'Events' do
             new_position = create(:position)
             visit new_event_path
 
-            #Mandatory fields
+            # Mandatory fields
             fill_in :event_title, with: "Title"
             fill_in :event_location, with: "Location"
             fill_in :event_scheduled, with: DateTime.current
             select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
             choose :event_lobby_activity_true
             fill_in :event_published_at, with: Date.current
-            #Participant fields
+            # Participant fields
             find('.add-participant').click
             sleep 0.5
 
@@ -200,14 +200,14 @@ feature 'Events' do
             new_position = create(:position)
             visit new_event_path
 
-            #Mandatory fields
+            # Mandatory fields
             fill_in :event_title, with: "Title"
             fill_in :event_location, with: "Location"
             fill_in :event_scheduled, with: DateTime.current
             select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
             choose :event_lobby_activity_true
             fill_in :event_published_at, with: Date.current
-            #Attendees fields
+            # Attendees fields
             find('.add-attendee').click
             find(".attendee-name").set("Name")
             click_button "Guardar"
@@ -222,14 +222,14 @@ feature 'Events' do
             new_position = create(:position)
             visit new_event_path
 
-            #Mandatory fields
+            # Mandatory fields
             fill_in :event_title, with: "Title"
             fill_in :event_location, with: "Location"
             fill_in :event_scheduled, with: DateTime.current
             select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
             choose :event_lobby_activity_true
             fill_in :event_published_at, with: Date.current
-            #Participant fields
+            # Participant fields
             find('.add-attendee').click
             find(".attendee-name").set("Name")
             find(".attendee-position").set("Position")
@@ -428,7 +428,6 @@ feature 'Events' do
       expect(page).to have_content event.title
     end
 
-
     describe "Create" do
 
       scenario 'visit new event page', :js do
@@ -464,7 +463,7 @@ feature 'Events' do
         visit new_event_path
 
         find(:radio_button, "event_lobby_activity_true", checked: true)
-        expect(find_field("event_organization_name").value).to eq "#{@organization.name}"
+        expect(find_field("event_organization_name").value).to eq @organization.name.to_s
       end
 
       scenario 'Visit new event page and not display specific admin/managers fields', :js do
@@ -584,6 +583,20 @@ feature 'Events' do
 
       end
 
+    end
+
+    describe "Edit" do
+      scenario "Edit buttons enabled for events on_request" do
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
+        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1)
+
+        visit events_path
+
+        puts page.body
+
+        expect(page).to have_content edit_event_path(event_requested)
+        expect(page).to_not have_content edit_event_path(event_accepted)
+      end
     end
 
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #49 

What
====
Allow organization users to edit events that are on request.

How
===
Adding permissions to the lobby users to enable the `edit` and `update` methods if the event's status is "requested".

Screenshots
===========
![edit01](https://user-images.githubusercontent.com/31625251/33564657-5ad15fa0-d91b-11e7-870b-868b09e2c993.png)

![edit02](https://user-images.githubusercontent.com/31625251/33564667-6005acc4-d91b-11e7-88fd-f8574a265bb5.png)

![edit03](https://user-images.githubusercontent.com/31625251/33564674-643552f4-d91b-11e7-8f71-9d723b4d8f2d.png)

![edit04](https://user-images.githubusercontent.com/31625251/33564690-68981886-d91b-11e7-88d7-2ed02b047ad3.png)

Test
====
Tests added to check that the organization users can only edit events on request.

Deployment
==========
Nothing.

Warnings
========
Nothing.
