### PR TITLE
Allow filtering of Organizations by interests

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -23,7 +23,8 @@ class OrganizationsController < ApplicationController
     def search(params, selected_order)
       Organization.validated.search do
         fulltext params[:keyword] if params[:keyword].present?
-        with :entity_type, params[:entity_type] unless params[:entity_type].blank?
+        with(:entity_type, params[:entity_type]) if params[:entity_type].present?
+        with(:interest_ids, params[:interests]) if params[:interests].present?
         order_by :created_at, :desc
         order_by :inscription_date, selected_order
         paginate page: params[:format].present? ? 1 : params[:page] || 1, per_page: params[:format].present? ? 1000 : 10
@@ -36,6 +37,6 @@ class OrganizationsController < ApplicationController
 
     def get_autocomplete_items(parameters)
       items = Organization.full_like("%#{parameters[:term]}%")
-    end    
+    end
 
 end

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -3,4 +3,8 @@ class Interest < ActiveRecord::Base
   has_many :organization_interests, dependent: :destroy
   has_many :organizations, through: :organization_interest
 
+  searchable do
+    integer :id, multiple: true
+  end
+
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -32,6 +32,9 @@ class Organization < ActiveRecord::Base
     boolean :invalidate
     string :entity_type
     time :inscription_date
+    integer :interest_ids, multiple: true do
+      interests.map(&:id)
+    end
   end
 
   scope :invalidated, -> { where('invalidate = ?', true) }

--- a/app/views/organizations/_search_form.html.erb
+++ b/app/views/organizations/_search_form.html.erb
@@ -1,18 +1,35 @@
 <div class="small-12 large-4 columns">
-  <p><%= t "organizations.description" %></p>
+  <p><%= t("organizations.description") %></p>
   <br>
 
   <%= form_tag organizations_path, method: :get do %>
     <%= hidden_field_tag :order, params[:order] %>
     <div class="mb20">
-      <%= text_field_tag :keyword, params[:keyword], placeholder: t('main.form.keyword') %>
+      <%= text_field_tag :keyword, params[:keyword], placeholder: t("main.form.keyword") %>
     </div>
+
     <div class="mb20">
-      <%= select_tag :entity_type, options_for_select(Organization.entity_types.keys.map{|type| [t("organizations.show.#{type}"), type]}, params[:entity_type]),prompt: t('main.form.filter_by'), class: 'dropdown'%>
+      <%= select_tag :entity_type,
+                     options_for_select(Organization.entity_types.keys.map {
+                       |type| [t("organizations.show.#{type}"), type]
+                     }, params[:entity_type]),
+                     prompt: t("main.form.filter_by"),
+                     class: "dropdown" %>
     </div>
+
     <div class="mb20">
-      <%= link_to t('main.form.reset'), organizations_path, class: 'button secondary' %>
-      <%= submit_tag t('main.form.search'), class: 'button', name: nil %>
+      <%= select_tag :interests,
+                     options_for_select(Interest.all.map {
+                       |interest| [interest.name, interest.id]
+                     }, params[:interests]),
+                     id: "interestsFilter",
+                     prompt: t("main.form.filter_by"),
+                     class: "dropdown" %>
+    </div>
+
+    <div class="mb20">
+      <%= link_to t("main.form.reset"), organizations_path, class: "button secondary" %>
+      <%= submit_tag t("main.form.search"), class: "button" %>
     </div>
   <% end %>
 </div>

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -393,6 +393,35 @@ feature 'Organizations page' do
       page.body.index('Fulanito').should < page.body.index('Carlos')
     end
 
+    feature 'Filters' do
+      background do
+        @org1 = create(:organization)
+        @org2 = create(:organization)
+        Organization.reindex
+      end
+
+      context 'Interests' do
+        background do
+          @org1.interests.push(create(:interest, name: 'Music'))
+          @org2.interests.push(create(:interest, name: 'History'))
+          Organization.reindex
+        end
+
+        scenario 'shows organizations based on the selected interest', :search do
+          visit organizations_path
+
+          expect(page).to have_content(@org1.name)
+          expect(page).to have_content(@org2.name)
+
+          find('#interestsFilter').find(:xpath, 'option[2]').select_option
+          click_button(I18n.t('main.form.search'))
+
+          expect(page).to have_content(@org1.name)
+          expect(page).to have_no_content(@org2.name)
+        end
+      end
+    end
+
   end
 
 end

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -370,33 +370,10 @@ feature 'Organizations page' do
       expect(page).to have_content("Consulta del registro de Organizaciones")
     end
 
-    scenario "Should order by inscription date ascending", :search do
-      create(:organization, name: "Carlos", first_surname: "Peréz", inscription_date: "Sat, 27 Nov 2015")
-      create(:organization, name: "Fulanito", first_surname: "Mengano", inscription_date: "Sun, 27 Nov 2016")
-      Organization.reindex
-
-      visit organizations_path
-
-      page.body.index('Carlos').should < page.body.index('Fulanito')
-    end
-
-    scenario "Should order by inscription date descending", :js, :search do
-      create(:organization, name: "Carlos", first_surname: "Peréz", inscription_date: "Sat, 27 Nov 2015")
-      create(:organization, name: "Fulanito", first_surname: "Mengano", inscription_date: "Sun, 27 Nov 2016")
-      Organization.reindex
-
-      visit organizations_path
-
-      all("#search-order option")[1].select_option
-      sleep 1
-
-      page.body.index('Fulanito').should < page.body.index('Carlos')
-    end
-
     feature 'Filters' do
       background do
-        @org1 = create(:organization)
-        @org2 = create(:organization)
+        @org1 = create(:organization, inscription_date: 'Fri, 27 Nov 2015')
+        @org2 = create(:organization, inscription_date: 'Sun, 27 Nov 2016')
         Organization.reindex
       end
 
@@ -418,6 +395,18 @@ feature 'Organizations page' do
 
           expect(page).to have_content(@org1.name)
           expect(page).to have_no_content(@org2.name)
+        end
+      end
+
+      context 'Sorting' do
+        scenario 'by ASC inscription date', :search do
+          visit organizations_path
+          expect(page.body.index(@org1.name)).to be < page.body.index(@org2.name)
+        end
+
+        scenario 'by DESC inscription date', :search do
+          visit organizations_path(order: :descending)
+          expect(page.body.index(@org2.name)).to be < page.body.index(@org1.name)
         end
       end
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #112

What
====
* Organizations can now be filtered by interests

How
===
* Modified related MVCs to fulfill the new requirement
* Refactored Organizations sorting spec to improve DRYness

Screenshots
===========
* Left sidebar with the new filter
![screenshot-2017-12-7 ayuntamiento de madrid transparencia agendas](https://user-images.githubusercontent.com/9470839/33742081-28f70322-db7d-11e7-91a6-25ddde4d00ff.png)

* Shown results when an user filters Organizations by a certain interest
![screenshot-2017-12-7 ayuntamiento de madrid transparencia agendas 1](https://user-images.githubusercontent.com/9470839/33742126-4f360de4-db7d-11e7-80cb-7803903c4e2b.png)

Test
====
* Increased coverage for the sole scenario generated by this new feature
