### PR TITLE
Only display default categories on organization#new

### DIFF
--- a/app/views/admin/organizations/_data.html.erb
+++ b/app/views/admin/organizations/_data.html.erb
@@ -33,7 +33,7 @@
     </div>
     <div class="small-12 columns">
       <%= f.label :category_id, t('backend.identifying_data.category_id') %>
-      <%= f.select :category_id, options_for_select(Category.all.map{|c| [c.name, c.id]}), prompt: t('backend.none') %>
+      <%= f.select :category_id, options_for_select(Category.where(display: true).map{|c| [c.name, c.id]}), prompt: t('backend.none') %>
       <%= form_field_errors(f, :category_id) %>
     </div>
     <div class="small-12 columns">

--- a/db/migrate/20171210174630_add_display_field_to_categories.rb
+++ b/db/migrate/20171210174630_add_display_field_to_categories.rb
@@ -1,0 +1,5 @@
+class AddDisplayFieldToCategories < ActiveRecord::Migration
+  def change
+    add_column :categories, :display, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171205234013) do
+ActiveRecord::Schema.define(version: 20171210174630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20171205234013) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean  "display"
   end
 
   create_table "event_agents", force: :cascade do |t|

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -115,7 +115,7 @@ names = ['Consultoría profesional y despachos de abogados', 'Empresas', 'Asocia
          'Iglesia y otras confesiones', 'Otro tipo de sujetos']
 
 names.each do |name|
-  Category.create(name: name)
+  Category.create(name: name, display: true)
 end
 
 #Category

--- a/lib/public_organization_importer.rb
+++ b/lib/public_organization_importer.rb
@@ -38,7 +38,7 @@ class PublicOrganizationImporter
   end
 
   def self.get_category(data)
-    Category.find_or_create_by(name: data["Categoría"])
+    Category.find_or_create_by(name: data["Categoría"], display: false)
   end
 
   def self.associations_mapping

--- a/lib/tasks/organizations.rake
+++ b/lib/tasks/organizations.rake
@@ -10,7 +10,7 @@ namespace :organizations do
              'Iglesia y otras confesiones', 'Otro tipo de sujetos']
 
     names.each do |name|
-      Category.find_or_create_by(name: name)
+      Category.find_or_create_by(name: name, display: true)
     end
   end
 

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
 
   factory :category do
     sequence(:name) { |n| "Category #{n}" }
+    display true
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #124 

# What
Only display categories by default.

# How
When import Organizations (Federations and Associations) from csv, we need create categories with a flag display: false, this categories not display on new organization page.

Test
====
- None

Deployment
==========
- As usual

Warnings
========
- None
