### PR TITLE
Remove filter by entity type. Only display organizations with entity :lobby

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -7,7 +7,7 @@ class OrganizationsController < ApplicationController
   def index
     selected_order = params[:order] == "descending" ? :desc : :asc
     @organizations = search(params, selected_order)
-    @paginated_organizations = Organization.validated.all.where(id: @organizations.hits.map(&:primary_key))
+    @paginated_organizations = Organization.lobbies.validated.all.where(id: @organizations.hits.map(&:primary_key))
     @paginated_organizations = @paginated_organizations.reorder(inscription_date: selected_order)
   end
 
@@ -21,9 +21,8 @@ class OrganizationsController < ApplicationController
   private
 
     def search(params, selected_order)
-      Organization.validated.search do
+      Organization.lobbies.validated.search do
         fulltext params[:keyword] if params[:keyword].present?
-        with(:entity_type, params[:entity_type]) if params[:entity_type].present?
         with(:interest_ids, params[:interests]) if params[:interests].present?
         order_by :created_at, :desc
         order_by :inscription_date, selected_order

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -38,7 +38,7 @@ class Organization < ActiveRecord::Base
 
   scope :invalidated, -> { where('invalidate = ?', true) }
   scope :validated, -> { where('invalidate = ?', false) }
-  scope :lobbies, -> { where('entity_type = ?', 2)}
+  scope :lobbies, -> { where('entity_type = ?', 2) }
   scope :full_like, ->(name) { where("identifier ilike ? OR name ilike ?", name, name) }
 
   def fullname

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -30,7 +30,6 @@ class Organization < ActiveRecord::Base
     text :name, :first_surname, :second_surname, :description
     time :created_at
     boolean :invalidate
-    string :entity_type
     time :inscription_date
     integer :interest_ids, multiple: true do
       interests.map(&:id)
@@ -39,6 +38,7 @@ class Organization < ActiveRecord::Base
 
   scope :invalidated, -> { where('invalidate = ?', true) }
   scope :validated, -> { where('invalidate = ?', false) }
+  scope :lobbies, -> { where('entity_type = ?', 2)}
   scope :full_like, ->(name) { where("identifier ilike ? OR name ilike ?", name, name) }
 
   def fullname

--- a/app/views/organizations/_search_form.html.erb
+++ b/app/views/organizations/_search_form.html.erb
@@ -9,15 +9,6 @@
     </div>
 
     <div class="mb20">
-      <%= select_tag :entity_type,
-                     options_for_select(Organization.entity_types.keys.map {
-                       |type| [t("organizations.show.#{type}"), type]
-                     }, params[:entity_type]),
-                     prompt: t("main.form.filter_by"),
-                     class: "dropdown" %>
-    </div>
-
-    <div class="mb20">
       <%= select_tag :interests,
                      options_for_select(Interest.all.map {
                        |interest| [interest.name, interest.id]

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -147,39 +147,17 @@ feature 'Organizations page' do
         expect(page).to have_content "Valid Org 1"
       end
 
-      scenario "Should filter by selected entity_type" do
-        create(:organization, entity_type: 'federation', name: "Federación 1")
-        create(:organization, entity_type: 'association', name: "Asociación 1")
-        create(:organization, entity_type: 'lobby', name: "Lobby 1")
+      scenario "Should display results with entity_type: lobby", :js do
+        create(:organization, entity_type: :federation, name: "Federación 1")
+        create(:organization, entity_type: :association, name: "Asociación 1")
+        create(:organization, entity_type: :lobby, name: "Lobby 1")
         Organization.reindex
 
         visit organizations_path
-        all('#entity_type option')[1].select_option
-        click_on "Buscar"
-        expect(page).not_to have_content "Lobby 1"
-        expect(page).to have_content "Asociación 1"
-        expect(page).not_to have_content "Federación 1"
 
-        visit organizations_path
-        all('#entity_type option')[2].select_option
-        click_on "Buscar"
-        expect(page).not_to have_content "Lobby 1"
-        expect(page).not_to have_content "Asociación 1"
-        expect(page).to have_content "Federación 1"
-
-        visit organizations_path
-        all('#entity_type option')[3].select_option
-        click_on "Buscar"
         expect(page).to have_content "Lobby 1"
         expect(page).not_to have_content "Asociación 1"
         expect(page).not_to have_content "Federación 1"
-
-        visit organizations_path
-        all('#entity_type option')[0].select_option
-        click_on "Buscar"
-        expect(page).to have_content "Lobby 1"
-        expect(page).to have_content "Asociación 1"
-        expect(page).to have_content "Federación 1"
       end
     end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #15 
* **Related PR's:** #94

# What
We have 3 entity_types from Organizations. Only need display on public organization index the organizations as lobby. 

*Note: entity_type: [:association, :federation, :lobby]

# How
- Render only organizations on public page with entity_type: :lobby
- Remove filter on public page that allow filter by :association, :federation, :lobby because now only display Organizations as lobby.

Test
====
- Fix specs.

Deployment
==========
- As usual.

Warnings
========
- None