### PR TITLE
Url lobby organizations events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -140,6 +140,19 @@ class Event < ActiveRecord::Base
     return event_ids
   end
 
+  def position_names
+    names = ''
+    positions.each do |position|
+      names += position.holder.full_name_comma + ' - ' + position.title
+      names += ' / ' unless position == positions.last
+    end
+    return names
+  end
+
+  def user_name
+    user.full_name
+  end
+
   private
 
     def participants_uniqueness

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,3 +116,25 @@ en:
     legal_representant_full_name: legal representant full name
     user_name: user name
     invalidate: invalidate
+  events_exporter:
+    title: título
+    description: descripción
+    scheduled: fecha
+    updated_at: última actualización
+    user_name: usuario
+    position_names: titular de la agenda
+    location: lugar
+    status: estado
+    notes: notas
+    reasons: razones
+    published_at: fecha pública
+    canceled_at: cancelado
+    lobby_activity: actividad de lobby
+    organization_name: organización
+    lobby_scheduled: descripción de fecha propuesta
+    general_remarks: observaciones generales
+    lobby_contact_firstname: nombre contacto
+    lobby_contact_lastname: apellido contacto
+    lobby_contact_email: email contacto
+    lobby_contact_phone: teléfono contacto
+    manager_general_remarks: observaciones generales del gestor

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -124,3 +124,25 @@ es:
     legal_representant_full_name: nombre y apellidos del representante legal
     user_name: nombre y apellidos
     invalidate: invalidada
+  events_exporter:
+    title: título
+    description: descripción
+    scheduled: fecha
+    updated_at: última actualización
+    user_name: usuario
+    position_names: titular de la agenda
+    location: lugar
+    status: estado
+    notes: notas
+    reasons: razones
+    published_at: fecha pública
+    canceled_at: cancelado
+    lobby_activity: actividad de lobby
+    organization_name: organización
+    lobby_scheduled: descripción de fecha propuesta
+    general_remarks: observaciones generales
+    lobby_contact_firstname: nombre contacto
+    lobby_contact_lastname: apellido contacto
+    lobby_contact_email: email contacto
+    lobby_contact_phone: teléfono contacto
+    manager_general_remarks: observaciones generales del gestor

--- a/lib/events_exporter.rb
+++ b/lib/events_exporter.rb
@@ -1,6 +1,6 @@
 class EventsExporter
-  FIELDS = ['title', 'description', 'scheduled', 'user_id', 'position_id', 'location', 'status',
-            'notes', 'reasons', 'published_at', 'canceled_at',
+  FIELDS = ['title', 'description', 'scheduled', 'updated_at', 'user_name', 'position_names', 'location', 'status',
+            'notes', 'reasons', 'published_at', 'canceled_at', 'lobby_activity',
             'organization_name', 'lobby_scheduled', 'general_remarks', 'lobby_contact_firstname',
             'lobby_contact_lastname', 'lobby_contact_email', 'lobby_contact_phone', 'manager_general_remarks'].freeze
 
@@ -25,7 +25,7 @@ class EventsExporter
   def save_csv(path)
     CSV.open(path, 'w', col_sep: ';', force_quotes: true, encoding: "ISO-8859-1") do |csv|
       csv << windows_headers
-      Event.with_lobby_activity_active.find_each do |event|
+      Event.find_each do |event|
         csv << windows_event_row(event)
       end
     end
@@ -37,7 +37,7 @@ class EventsExporter
     sheet.row(0).default_format = Spreadsheet::Format.new color: :blue, weight: :bold
     sheet.row(0).concat headers
     index = 1
-    Event.with_lobby_activity_active.find_each do |event|
+    Event.find_each do |event|
       sheet.row(index).concat windows_event_row(event)
       index += 1
     end
@@ -48,7 +48,7 @@ class EventsExporter
   def save_json(path)
     data = []
     h = headers
-    Event.with_lobby_activity_active.find_each do |event|
+    Event.find_each do |event|
       data << h.zip(windows_event_row(event)).to_h
     end
     File.open(path, "w") do |f|
@@ -59,7 +59,7 @@ class EventsExporter
   private
 
     def windows_array(values)
-      values.map { |v| v.to_s.encode("ISO-8859-1", invalid: :replace, undef: :replace, replace: '') }
+      values.map { |v| v.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: '') }
     end
 
 end

--- a/lib/events_exporter.rb
+++ b/lib/events_exporter.rb
@@ -1,0 +1,65 @@
+class EventsExporter
+  FIELDS = ['title', 'description', 'scheduled', 'user_id', 'position_id', 'location', 'status',
+            'notes', 'reasons', 'published_at', 'canceled_at',
+            'organization_name', 'lobby_scheduled', 'general_remarks', 'lobby_contact_firstname',
+            'lobby_contact_lastname', 'lobby_contact_email', 'lobby_contact_phone', 'manager_general_remarks'].freeze
+
+  def headers
+    FIELDS.map { |f| I18n.t("events_exporter.#{f}") }
+  end
+
+  def event_to_row(event)
+    FIELDS.map do |f|
+      event.send(f)
+    end
+  end
+
+  def windows_headers
+    windows_array headers
+  end
+
+  def windows_event_row(event)
+    windows_array event_to_row(event)
+  end
+
+  def save_csv(path)
+    CSV.open(path, 'w', col_sep: ';', force_quotes: true, encoding: "ISO-8859-1") do |csv|
+      csv << windows_headers
+      Event.with_lobby_activity_active.find_each do |event|
+        csv << windows_event_row(event)
+      end
+    end
+  end
+
+  def save_xls(path)
+    book = Spreadsheet::Workbook.new
+    sheet = book.create_worksheet
+    sheet.row(0).default_format = Spreadsheet::Format.new color: :blue, weight: :bold
+    sheet.row(0).concat headers
+    index = 1
+    Event.with_lobby_activity_active.find_each do |event|
+      sheet.row(index).concat windows_event_row(event)
+      index += 1
+    end
+
+    book.write(path)
+  end
+
+  def save_json(path)
+    data = []
+    h = headers
+    Event.with_lobby_activity_active.find_each do |event|
+      data << h.zip(windows_event_row(event)).to_h
+    end
+    File.open(path, "w") do |f|
+      f.write(data.to_json)
+    end
+  end
+
+  private
+
+    def windows_array(values)
+      values.map { |v| v.to_s.encode("ISO-8859-1", invalid: :replace, undef: :replace, replace: '') }
+    end
+
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -16,4 +16,18 @@ namespace :export do
     exporter.save_json(folder.join('public_organizations.json'))
   end
 
+  desc "Exports organizations' events to public/export/organizations_events.csv,
+        public/export/organizations_events.xls and public/export/organizations_events.json"
+  task events: :environment do
+    folder = Rails.root.join('public', 'export')
+    FileUtils.rm_rf folder
+    FileUtils.mkdir_p folder
+
+    exporter = EventsExporter.new
+
+    exporter.save_csv(folder.join('organizations_events.csv'))
+    exporter.save_xls(folder.join('organizations_events.xls'))
+    exporter.save_json(folder.join('organizations_events.json'))
+  end
+
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -2,32 +2,30 @@ require 'public_organization_exporter'
 require 'fileutils'
 
 namespace :export do
-  desc "Exports organizations to public/export/public_organizations.csv,
-        public/export/public_organizations.xls and public/export/public_organizations.json"
+  desc "Exports organizations to public/export/lobbies.csv,
+        public/export/lobbies.xls and public/export/lobbies.json"
   task organizations: :environment do
     folder = Rails.root.join('public', 'export')
-    FileUtils.rm_rf folder
-    FileUtils.mkdir_p folder
+    FileUtils.mkdir_p folder unless Dir.exist?(folder)
 
     exporter = PublicOrganizationExporter.new
 
-    exporter.save_csv(folder.join('public_organizations.csv'))
-    exporter.save_xls(folder.join('public_organizations.xls'))
-    exporter.save_json(folder.join('public_organizations.json'))
+    exporter.save_csv(folder.join('lobbies.csv'))
+    exporter.save_xls(folder.join('lobbies.xls'))
+    exporter.save_json(folder.join('lobbies.json'))
   end
 
-  desc "Exports organizations' events to public/export/organizations_events.csv,
-        public/export/organizations_events.xls and public/export/organizations_events.json"
-  task events: :environment do
+  desc "Exports organizations' events to public/export/agendas.csv,
+        public/export/agendas.xls and public/export/agendas.json"
+  task agendas: :environment do
     folder = Rails.root.join('public', 'export')
-    FileUtils.rm_rf folder
-    FileUtils.mkdir_p folder
+    FileUtils.mkdir_p folder unless Dir.exist?(folder)
 
     exporter = EventsExporter.new
 
-    exporter.save_csv(folder.join('organizations_events.csv'))
-    exporter.save_xls(folder.join('organizations_events.xls'))
-    exporter.save_json(folder.join('organizations_events.json'))
+    exporter.save_csv(folder.join('agendas.csv'))
+    exporter.save_xls(folder.join('agendas.xls'))
+    exporter.save_json(folder.join('agendas.json'))
   end
 
 end

--- a/spec/events_exporter_spec.rb
+++ b/spec/events_exporter_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'events_exporter'
+
+describe EventsExporter do
+  let(:exporter) { EventsExporter.new }
+
+  describe '#headers' do
+    it "generates localized headers" do
+      expect(exporter.headers.first).to eq('título')
+      expect(exporter.headers.last).to eq('observaciones generales del gestor')
+    end
+  end
+
+  describe '#events_to_row' do
+    it "generates a row of info based on a event" do
+      position = create(:position)
+      event = create(:event, organization_name: "Organization name", position: position)
+
+      row = exporter.event_to_row(event)
+
+      expect(row).to include(event.title)
+      expect(row).to include(event.description)
+      expect(row).to include(event.scheduled)
+      expect(row).to include(event.updated_at)
+      expect(row).to include(event.user_name)
+      expect(row).to include(event.position_names)
+      expect(row).to include(event.location)
+      expect(row).to include(event.status)
+      expect(row).to include(event.notes)
+      expect(row).to include(event.reasons)
+      expect(row).to include(event.published_at)
+      expect(row).to include(event.canceled_at)
+      expect(row).to include(event.organization_name)
+      expect(row).to include(event.lobby_scheduled)
+      expect(row).to include(event.general_remarks)
+      expect(row).to include(event.lobby_contact_firstname)
+      expect(row).to include(event.lobby_contact_lastname)
+      expect(row).to include(event.lobby_scheduled)
+      expect(row).to include(event.general_remarks)
+      expect(row).to include(event.lobby_contact_phone)
+      expect(row).to include(event.manager_general_remarks)
+
+    end
+  end
+
+end

--- a/spec/lib/tasks/export_rake_spec.rb
+++ b/spec/lib/tasks/export_rake_spec.rb
@@ -7,9 +7,9 @@ describe "export:organizations" do
   it "check files existence a files contents" do
     subject.invoke
 
-    csv_file = File.open(Rails.root.to_s + '/public/export/public_organizations.csv')
-    json_file = File.open(Rails.root.to_s + '/public/export/public_organizations.json')
-    xls_file = File.open(Rails.root.to_s + '/public/export/public_organizations.xls')
+    csv_file = File.open(Rails.root.to_s + '/public/export/lobbies.csv')
+    json_file = File.open(Rails.root.to_s + '/public/export/lobbies.json')
+    xls_file = File.open(Rails.root.to_s + '/public/export/lobbies.xls')
 
     expect(File).to exist(csv_file)
     expect(File).to exist(json_file)
@@ -21,7 +21,7 @@ describe "export:organizations" do
     o.save!
 
     subject.invoke
-    csv_file = File.open(Rails.root.to_s + '/public/export/public_organizations.csv').read.scrub
+    csv_file = File.open(Rails.root.to_s + '/public/export/lobbies.csv').read.scrub
 
     csv = CSV.parse(csv_file, headers: true, col_sep: ';')
     expect(csv.first.to_hash.values[0]).to eq(o.reference)
@@ -32,7 +32,7 @@ describe "export:organizations" do
     o.save!
 
     subject.invoke
-    json_file = File.open(Rails.root.to_s + '/public/export/public_organizations.json')
+    json_file = File.open(Rails.root.to_s + '/public/export/lobbies.json')
 
     parsed_json = ActiveSupport::JSON.decode(json_file.read)
     expect(parsed_json.first.values.first).to eq(o.reference)
@@ -43,12 +43,65 @@ describe "export:organizations" do
     o.save!
 
     subject.invoke
-    xls_file = File.open(Rails.root.to_s + '/public/export/public_organizations.xls')
+    xls_file = File.open(Rails.root.to_s + '/public/export/lobbies.xls')
 
     require 'spreadsheet'
     book = Spreadsheet.open(xls_file)
     sheet = book.worksheets[0]
     expect(sheet.rows[1][0]).to eq(o.reference)
+  end
+
+end
+
+describe "export:agendas" do
+
+  include_context "rake"
+
+  it "check files existence a files contents" do
+    subject.invoke
+
+    csv_file = File.open(Rails.root.to_s + '/public/export/agendas.csv')
+    json_file = File.open(Rails.root.to_s + '/public/export/agendas.json')
+    xls_file = File.open(Rails.root.to_s + '/public/export/agendas.xls')
+
+    expect(File).to exist(csv_file)
+    expect(File).to exist(json_file)
+    expect(File).to exist(xls_file)
+  end
+
+  it "check csv contents" do
+    o = create(:event)
+    o.save!
+
+    subject.invoke
+    csv_file = File.open(Rails.root.to_s + '/public/export/agendas.csv').read.scrub
+
+    csv = CSV.parse(csv_file, headers: true, col_sep: ';')
+    expect(csv.first.to_hash.values[0]).to eq(o.title)
+  end
+
+  it "check json contents" do
+    o = create(:event)
+    o.save!
+
+    subject.invoke
+    json_file = File.open(Rails.root.to_s + '/public/export/agendas.json')
+
+    parsed_json = ActiveSupport::JSON.decode(json_file.read)
+    expect(parsed_json.first.values.first).to eq(o.title)
+  end
+
+  it "check xsl contents" do
+    o = create(:event)
+    o.save!
+
+    subject.invoke
+    xls_file = File.open(Rails.root.to_s + '/public/export/agendas.xls')
+
+    require 'spreadsheet'
+    book = Spreadsheet.open(xls_file)
+    sheet = book.worksheets[0]
+    expect(sheet.rows[1][0]).to eq(o.title)
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #106 

What
====
Generation of a file that contains the lobby informations and the events. This files must be accessible in a public URL.

How
===
- Generate the exporter to build the .csv, .xls and the .json files.
- Create a rake task to save this files in the public/export/filename.ext

Screenshots
===========
There aren't.

Test
====
Specs to test the exporter and the new rake task.

Deployment
==========
In order to generate the files, the rake task should be run.

Warnings
========
Nothing to apply.
