### PR TITLE
Issue 51 manager and organization user event index

### DIFF
--- a/app/assets/javascripts/events.js.erb
+++ b/app/assets/javascripts/events.js.erb
@@ -147,10 +147,10 @@ $(function(){
 
 function fill_represented_entities_select_options() {
   $('#nested-event-represented-entities').bind('cocoon:after-insert', function() {
-    if ($('#organization_id').val()){
+    if ($('#event_organization_reference_id').val()){
       $.ajax({
         method: "GET",
-        url: $('.represented-entities-block').data('new-url').replace('organization_id', $('#organization_id').val())
+        url: $('.represented-entities-block').data('new-url').replace('organization_id', $('#event_organization_reference_id').val())
       }).done(function( represented_entities ) {
         var select = $('#nested-event-represented-entities select:last');
         if (represented_entities.length > 0)  {
@@ -172,10 +172,10 @@ function fill_represented_entities_select_options() {
 
 function fill_agents_select_options() {
   $('#nested-event-agents').bind('cocoon:after-insert', function() {
-    if ($('#organization_id').val()){
+    if ($('#event_organization_reference_id').val()){
       $.ajax({
         method: "GET",
-        url: $('.agents-block').data('new-url').replace('organization_id', $('#organization_id').val())
+        url: $('.agents-block').data('new-url').replace('organization_id', $('#event_organization_reference_id').val())
       }).done(function( agents ) {
         var select = $('#nested-event-agents select:last');
         if (agents.length > 0)  {
@@ -200,12 +200,12 @@ function fill_autocomplete_organization_name() {
   $('#event_organization_name').bind('railsAutocomplete.select', function(event, data){
     $('#nested-event-represented-entities .link_to_remove_association').trigger('click');
     $('#nested-event-agents .link_to_remove_association').trigger('click');
-    $('#organization_id').val(data.item.id);
+    $('#event_organization_reference_id').val(data.item.id);
     $('#event-category').empty();
-    if ($('#organization_id').val()){
+    if ($('#event_organization_reference_id').val()){
       $.ajax({
         method: "GET",
-        url: $('#category-block').data('new-url').replace('organization_id', $('#organization_id').val())
+        url: $('#category-block').data('new-url').replace('organization_id', $('#event_organization_reference_id').val())
       }).done(function( category ) {
         var div_category = $('#event-category');
         div_category.append(category);

--- a/app/assets/stylesheets/all.css.scss
+++ b/app/assets/stylesheets/all.css.scss
@@ -3142,8 +3142,10 @@ select:hover {
 select:disabled {
   background-color: #DDDDDD;
   cursor: default; }
+
 select[multiple] {
-  height: auto; }
+  height: auto;
+}
 
 /* Adjust margin for form elements below */
 input[type="file"], input[type="checkbox"], input[type="radio"], select {

--- a/app/assets/stylesheets/all.css.scss
+++ b/app/assets/stylesheets/all.css.scss
@@ -7314,7 +7314,6 @@ select {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
   }
-
 }
 
 .ui-autocomplete{
@@ -7359,5 +7358,64 @@ ul.accordion{
   }
   .active .accordion-icon:before {
     content: "-";
+  }
+}
+
+#search_form{
+  label{
+    display: inline-block;
+  }
+  .event-status-search-options{
+    small{
+      float:right;
+    }
+  }
+}
+
+
+[data-tooltip-custom] {
+  position: relative;
+  z-index: 2;
+  cursor: pointer;
+
+  &:before,
+  &:after{
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    bottom: 150%;
+    left: 50%;
+  }
+
+  &:before {
+    margin-bottom: 5px;
+    margin-left: -80px;
+    padding: 7px;
+    width: 160px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    background-color: #000;
+    color: #fff;
+    content: attr(data-tooltip-custom);
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.2;
+  }
+  &:after {
+    margin-left: -5px;
+    width: 0;
+    border-top: 5px solid #000;
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    content: " ";
+    font-size: 0;
+    line-height: 0;
+  }
+  &:hover:before,
+  &:hover:after {
+    visibility: visible;
+    opacity: 1;
   }
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < AdminController
   before_action :set_event, only: [:edit, :update]
 
   def index
-    @events = current_user.admin? ? list_admin_events : list_user_events
+    @events = current_user.admin?  || current_user.lobby? ? list_admin_events : list_user_events
   end
 
   def create
@@ -45,7 +45,7 @@ class EventsController < AdminController
 
   def event_params
     params.require(:event).permit(:title, :description, :location, :scheduled, :position_id, :search_title, :search_person,
-                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel,
+                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel,:organization_id,
                                   :organization_name, :lobby_scheduled, :general_remarks, :lobby_contact_firstname,
                                   :lobby_contact_lastname, :lobby_contact_phone, :lobby_contact_email, :lobby_general_remarks,
                                   event_represented_entities_attributes: [:id, :name, :_destroy],
@@ -62,7 +62,7 @@ class EventsController < AdminController
   end
 
   def list_admin_events
-    @events = Event.searches(params[:search_person], params[:search_title], params[:lobby_activity])
+    @events = Event.searches(search_params(params))
     @events.order(scheduled: :desc).page(params[:page]).per(50)
   end
 
@@ -74,6 +74,30 @@ class EventsController < AdminController
 
   def set_event
     @event = Event.find(params[:id])
+  end
+
+  def find_holder_id_by_name (name)
+    holder_ids =Holder.by_name(name).pluck(:id)
+    array_position=Position.where("positions.holder_id IN (?)", holder_ids)
+  end
+
+  def emun_status(array_status)
+      @status= array_status.map{|status| Event.statuses[status]}.join(' , ') if array_status.present?
+  end
+
+  def search_params(params)
+    person = params[:search_person]
+    title = params[:search_title]
+    lobby_activity = params[:lobby_activity]
+    status = emun_status(params[:status])
+    role = current_user.role
+    params_searches = Hash.new
+    params_searches[:title] = title if !title.blank?
+    params_searches[:lobby_activity] = "1" if !lobby_activity.blank?
+    params_searches[:status] = emun_status(params[:status]) if status.present?
+    params_searches[:position_id] = find_holder_id_by_name(params[:search_person]) if person.present?
+    params_searches[:organization_id] = current_user.organization_id if role == "lobby"
+    params_searches
   end
 
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < AdminController
   before_action :set_event, only: [:edit, :update]
 
   def index
-    @events = current_user.admin?  || current_user.lobby? ? list_admin_events : list_user_events
+    @events = current_user.admin? || current_user.lobby? ? list_admin_events : list_user_events
   end
 
   def create
@@ -45,7 +45,7 @@ class EventsController < AdminController
 
   def event_params
     params.require(:event).permit(:title, :description, :location, :scheduled, :position_id, :search_title, :search_person,
-                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel,:organization_id,
+                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel, :organization_id,
                                   :organization_name, :lobby_scheduled, :general_remarks, :lobby_contact_firstname,
                                   :lobby_contact_lastname, :lobby_contact_phone, :lobby_contact_email, :lobby_general_remarks,
                                   event_represented_entities_attributes: [:id, :name, :_destroy],
@@ -76,13 +76,13 @@ class EventsController < AdminController
     @event = Event.find(params[:id])
   end
 
-  def find_holder_id_by_name (name)
-    holder_ids =Holder.by_name(name).pluck(:id)
-    array_position=Position.where("positions.holder_id IN (?)", holder_ids)
+  def find_holder_id_by_name(name)
+    holder_ids = Holder.by_name(name).pluck(:id)
+    array_position = Position.where("positions.holder_id IN (?)", holder_ids)
   end
 
   def emun_status(array_status)
-      @status= array_status.map{|status| Event.statuses[status]}.join(' , ') if array_status.present?
+      @status = array_status.map { |status| Event.statuses[status] }.join(' , ') if array_status.present?
   end
 
   def search_params(params)
@@ -91,9 +91,9 @@ class EventsController < AdminController
     lobby_activity = params[:lobby_activity]
     status = emun_status(params[:status])
     role = current_user.role
-    params_searches = Hash.new
-    params_searches[:title] = title if !title.blank?
-    params_searches[:lobby_activity] = "1" if !lobby_activity.blank?
+    params_searches = {}
+    params_searches[:title] = title unless title.blank?
+    params_searches[:lobby_activity] = "1" unless lobby_activity.blank?
     params_searches[:status] = emun_status(params[:status]) if status.present?
     params_searches[:position_id] = find_holder_id_by_name(params[:search_person]) if person.present?
     params_searches[:organization_id] = current_user.organization_id if role == "lobby"

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -81,22 +81,21 @@ class EventsController < AdminController
     array_position = Position.where("positions.holder_id IN (?)", holder_ids)
   end
 
-  def emun_status(array_status)
+  def enum_status(array_status)
     @status = array_status.map { |status| Event.statuses[status] }.join(' , ') if array_status.present?
   end
 
   def search_params(params)
     person = params[:search_person]
     title = params[:search_title]
-    lobby_activity = params[:lobby_activity]
-    status = emun_status(params[:status])
-    role = current_user.role
+    status = enum_status(params[:status])
+    
     params_searches = {}
     params_searches[:title] = title unless title.blank?
-    params_searches[:lobby_activity] = "1" unless lobby_activity.blank?
-    params_searches[:status] = emun_status(params[:status]) if status.present?
-    params_searches[:position_id] = find_holder_id_by_name(params[:search_person]) if person.present?
-    params_searches[:organization_id] = current_user.organization_id if role == "lobby"
+    params_searches[:lobby_activity] = "1" unless params[:lobby_activity].blank?
+    params_searches[:status] = status if status.present?
+    params_searches[:position_id] = find_holder_id_by_name(person) if person.present?
+    params_searches[:organization_id] = current_user.organization_id if current_user.role == "lobby"
     params_searches
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -67,7 +67,7 @@ class EventsController < AdminController
   end
 
   def list_user_events
-    @events = Event.managed_by(current_user)
+    @events = Event.managed_by(current_user).searches(search_params(params))
                    .includes(:position, :attachments, position: [:holder])
     @events.order(scheduled: :desc).page(params[:page]).per(50)
   end
@@ -82,7 +82,7 @@ class EventsController < AdminController
   end
 
   def emun_status(array_status)
-      @status = array_status.map { |status| Event.statuses[status] }.join(' , ') if array_status.present?
+    @status = array_status.map { |status| Event.statuses[status] }.join(' , ') if array_status.present?
   end
 
   def search_params(params)

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -51,5 +51,12 @@ module Admin
         email
       end
     end
+
+    def event_status_search_options (selected)
+      rev=Hash.new
+      t("backend.status").each_with_index {|(k,v),index| rev[v]=k}
+      return options_for_select(rev, selected)
+    end
+
   end
 end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -52,8 +52,8 @@ module Admin
       end
     end
 
-    def event_status_search_options (selected)
-      rev= {}
+    def event_status_search_options(selected)
+      rev = {}
       t("backend.status").each_with_index { |(k, v)| rev[v] = k }
       options_for_select(rev, selected)
     end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -53,10 +53,9 @@ module Admin
     end
 
     def event_status_search_options (selected)
-      rev=Hash.new
-      t("backend.status").each_with_index {|(k,v),index| rev[v]=k}
-      return options_for_select(rev, selected)
+      rev= {}
+      t("backend.status").each_with_index { |(k, v)| rev[v] = k }
+      options_for_select(rev, selected)
     end
-
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -88,7 +88,7 @@ class Event < ActiveRecord::Base
     else
       events = all
     end
-      events
+    events
   end
 
   searchable do
@@ -154,6 +154,12 @@ class Event < ActiveRecord::Base
     user.full_name
   end
 
+  def self.filter(attributes)
+    attributes.slice(*SUPPORTED_FILTERS).reduce(all) do |scope, (key, value)|
+      value.present? ? scope.send(key, value) : scope
+    end
+  end
+
   private
 
     def participants_uniqueness
@@ -181,12 +187,6 @@ class Event < ActiveRecord::Base
     def role_validate_scheduled
       return if self.user.lobby? || self.scheduled.present?
       errors.add(:base, "Fecha del evento no puede estar en blanco")
-    end
-
-    def self.filter(attributes)
-      attributes.slice(*SUPPORTED_FILTERS).reduce(all) do |scope, (key, value)|
-        value.present? ? scope.send(key, value) : scope
-      end
     end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ActiveRecord::Base
   include PublicActivity::Model
 
   attr_accessor :cancel
+  attr_accessor :organization_reference_id
 
   tracked owner: Proc.new { |controller, model| controller.present? ? controller.current_user : model.user }
   tracked title: Proc.new { |controller, model| controller.present? ? controller.get_title : model.title }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,6 @@
 class Event < ActiveRecord::Base
   include PublicActivity::Model
 
-  attr_accessor :organization_id
   attr_accessor :cancel
 
   tracked owner: Proc.new { |controller, model| controller.present? ? controller.current_user : model.user }
@@ -20,6 +19,7 @@ class Event < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :position
+  belongs_to :organization
   has_many :participants, dependent: :destroy
   has_many :positions, through: :participants
   has_many :attachments, dependent: :destroy
@@ -33,9 +33,9 @@ class Event < ActiveRecord::Base
   accepts_nested_attributes_for :attachments, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :participants, reject_if: :all_blank, allow_destroy: true
 
-  enum status: { requested: 0, accepted: 1, canceled: 4 }
 
-  scope :by_title, lambda {|title| where("title ILIKE ?", "%#{title}%") }
+  SUPPORTED_FILTERS = [:title, :position_id, :lobby_activity, :status , :organization_id]
+  scope :title, lambda {|title| where("title ILIKE ?", "%#{title}%") }
   scope :by_holders, lambda {|holder_ids|
     joins(:position).where("positions.holder_id IN (?)", holder_ids)
   }
@@ -46,10 +46,12 @@ class Event < ActiveRecord::Base
     holder_ids = Holder.by_name(name).pluck(:id)
     joins(:position).where("positions.holder_id IN (?)", holder_ids)
   }
-
-  scope :with_lobby_activity_active, -> { where(lobby_activity: true) }
+  scope :status, -> (status) { where("status IN (#{status})") }
+  scope :lobby_activity, -> (lobby_activity){ where(lobby_activity: lobby_activity) }
+  scope :position_id, -> (position) { where(position_id: position) }
+  scope :organization_id, -> (organization) { where(organization_id: organization) }
   scope :published, -> { where("published_at <= ? AND status != ?", Time.zone.today, 4) }
-
+  enum status: { requested: 0, accepted: 1 , done: 2 ,  declined: 3, canceled: 4 }
   def cancel_event
     return unless cancel == 'true' && canceled_at.nil?
     self.canceled_at = Time.zone.today
@@ -80,15 +82,13 @@ class Event < ActiveRecord::Base
     ability(user, 'participants_events')
   end
 
-  def self.searches(search_person, search_title, search_lobby_activity)
-    if search_person.present? || search_title.present? || search_lobby_activity.present?
-      @events = by_holder_name(search_person).uniq if search_person.present?
-      @events = by_title(search_title) if search_title.present?
-      @events = with_lobby_activity_active if search_lobby_activity
+  def self.searches(params)
+    if params.any?
+      @events = filter(params)
     else
       @events = all
     end
-    @events
+      @events
   end
 
   searchable do
@@ -182,4 +182,11 @@ class Event < ActiveRecord::Base
       return if self.user.lobby? || self.scheduled.present?
       errors.add(:base, "Fecha del evento no puede estar en blanco")
     end
+
+    def self.filter(attributes)
+      attributes.slice(*SUPPORTED_FILTERS).reduce(all) do |scope, (key, value)|
+        value.present? ? scope.send(key, value) : scope
+      end
+    end
+
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -33,8 +33,7 @@ class Event < ActiveRecord::Base
   accepts_nested_attributes_for :attachments, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :participants, reject_if: :all_blank, allow_destroy: true
 
-
-  SUPPORTED_FILTERS = [:title, :position_id, :lobby_activity, :status , :organization_id]
+  SUPPORTED_FILTERS = [:title, :position_id, :lobby_activity, :status, :organization_id].freeze
   scope :title, lambda {|title| where("title ILIKE ?", "%#{title}%") }
   scope :by_holders, lambda {|holder_ids|
     joins(:position).where("positions.holder_id IN (?)", holder_ids)
@@ -46,12 +45,12 @@ class Event < ActiveRecord::Base
     holder_ids = Holder.by_name(name).pluck(:id)
     joins(:position).where("positions.holder_id IN (?)", holder_ids)
   }
-  scope :status, -> (status) { where("status IN (#{status})") }
-  scope :lobby_activity, -> (lobby_activity){ where(lobby_activity: lobby_activity) }
-  scope :position_id, -> (position) { where(position_id: position) }
-  scope :organization_id, -> (organization) { where(organization_id: organization) }
-  scope :published, -> { where("published_at <= ? AND status != ?", Time.zone.today, 4) }
-  enum status: { requested: 0, accepted: 1 , done: 2 ,  declined: 3, canceled: 4 }
+  scope :status, ->(status) { where("status IN (#{status})") }
+  scope :lobby_activity, ->(lobby_activity){ where(lobby_activity: lobby_activity) }
+  scope :position_id, ->(position) { where(position_id: position) }
+  scope :organization_id, ->(organization) { where(organization_id: organization) }
+  scope :published, ->{ where("published_at <= ? AND status != ?", Time.zone.today, 4) }
+  enum status: { requested: 0, accepted: 1, done: 2, declined: 3, canceled: 4 }
   def cancel_event
     return unless cancel == 'true' && canceled_at.nil?
     self.canceled_at = Time.zone.today

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -83,12 +83,12 @@ class Event < ActiveRecord::Base
   end
 
   def self.searches(params)
-    if params.any?
-      @events = filter(params)
+    if params.present?
+      events = filter(params)
     else
-      @events = all
+      events = all
     end
-      @events
+      events
   end
 
   searchable do

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,6 +13,7 @@ class Organization < ActiveRecord::Base
   has_many :subventions, dependent: :destroy
   has_many :contracts, dependent: :destroy
   has_many :funds, dependent: :destroy
+  has_many :event
   has_one :comunication_representant, dependent: :destroy
   has_one :user, dependent: :destroy
   has_one :legal_representant, dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,7 +13,7 @@ class Organization < ActiveRecord::Base
   has_many :subventions, dependent: :destroy
   has_many :contracts, dependent: :destroy
   has_many :funds, dependent: :destroy
-  has_many :event
+  has_many :events
   has_one :comunication_representant, dependent: :destroy
   has_one :user, dependent: :destroy
   has_one :legal_representant, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,4 +69,8 @@ class User < ActiveRecord::Base
     user.save
   end
 
+  def self.lobby?
+    true if self.role="lobby"
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ActiveRecord::Base
   end
 
   def self.lobby?
-    true if self.role="lobby"
+    true if self.role == "lobby"
   end
 
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -79,19 +79,15 @@
       <div class="small-12 error-radio-buttons"></div>
 
       <div id="lobby-activity-event">
-        <% if current_user.lobby? %>
-          <%= f.hidden_field  :organization_id, :value => current_user.organization_id %>
-          <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input'), value: current_user.organization.name, readonly: true %>
-        <% else %>
-          <%= f.hidden_field :organization_id %>
-          <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input') %>
-        <% end %>
-        <div id="category-block" style="display: none" data-new-url="<%= organization_category_url_pattern %>">
-          <div class="row">
-            <div class="small-10 columns"><%= t('backend.meeting_lobby_category') %> <i id="event-category"></i></div>
-            <div class="small-2 columns"></div>
-          </div>
-          <hr />
+        <div class="lobby-organization-autocomplete">
+          <%= t('backend.meeting_lobby_activity_organization') %>
+          <% if current_user.lobby? %>
+            <%= f.hidden_field :organization_reference_id, :value => current_user.organization_id %>
+            <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input'), value: current_user.organization.name, readonly: true %>
+          <% else %>
+            <%= f.hidden_field :organization_reference_id %>
+            <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input') %>
+          <% end %>
         </div>
 
         <% if current_user.lobby? %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -79,15 +79,19 @@
       <div class="small-12 error-radio-buttons"></div>
 
       <div id="lobby-activity-event">
-        <div class="lobby-organization-autocomplete">
-          <%= t('backend.meeting_lobby_activity_organization') %>
-          <% if current_user.lobby? %>
-            <%= hidden_field_tag  :organization_id, current_user.organization_id %>
-            <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input'), value: current_user.organization.name, readonly: true %>
-          <% else %>
-            <%= hidden_field_tag  :organization_id %>
-            <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input') %>
-          <% end %>
+        <% if current_user.lobby? %>
+          <%= f.hidden_field  :organization_id, :value => current_user.organization_id %>
+          <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input'), value: current_user.organization.name, readonly: true %>
+        <% else %>
+          <%= f.hidden_field :organization_id %>
+          <%= f.autocomplete_field :organization_name, autocomplete_organization_name_organizations_path, :update_elements => {}, placeholder: t('backend.meeting_lobby_activity_input') %>
+        <% end %>
+        <div id="category-block" style="display: none" data-new-url="<%= organization_category_url_pattern %>">
+          <div class="row">
+            <div class="small-10 columns"><%= t('backend.meeting_lobby_category') %> <i id="event-category"></i></div>
+            <div class="small-2 columns"></div>
+          </div>
+          <hr />
         </div>
 
         <% if current_user.lobby? %>

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -1,13 +1,17 @@
-<% if current_user.admin? %>
+<% if current_user.admin? || current_user.lobby? %>
   <%= form_tag events_path, method: :get do %>
   <div class="small-12 columns" id="search_form">
-    <div class="small-6 columns">
+    <div class="small-4 columns">
       <%= label_tag(:search_title, t("backend.search.title")) %>
-      <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>" onchange="form.search_person.value=''">
+      <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>">
     </div>
-    <div class="small-6 columns">
+    <div class="small-4 columns">
       <%= label_tag(:search_person, t("backend.search.person")) %>
-      <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>"  onchange="form.search_title.value=''">
+      <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
+    </div>
+    <div class="small-4 columns">
+      <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
+      <%= select_tag :status, event_status_search_options(params[:status]) , {include_blank: true , multiple: true}  %>
     </div>
   </div>
   <div class="small-12 columns">

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -23,9 +23,10 @@
         <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
       </div>
 
-      <div class="small-12 medium-5 columns">
+      <div class="small-12 medium-5 columns event-status-search-options">
         <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
-        <%= select_tag :status, event_status_search_options(params[:status]) , {include_blank: 'Selecciona estado' , multiple: true }  %>
+        <small><a href="#" data-tooltip-custom="<%= t("backend.search.tool_tips_multiple_selection") %>"><%= t("backend.search.multiple_selection") %></a></small>
+        <%= select_tag :status, event_status_search_options(params[:status]) , { multiple: true }  %>
         <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
         <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
         <input type="submit" class="expanded button tiny radius right" value="<%= t("backend.search.button") %>">
@@ -33,6 +34,4 @@
     </div>
     <hr />
   <% end %>
-<% else %>
-  <%#= link_to t('backend.new_event'), new_event_path, :class => "expanded button tiny radius warning" if can? :create, Event %>
 <% end %>

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -1,36 +1,38 @@
 <% if current_user.admin? || current_user.lobby? %>
+  <div class="row">
+    <div class="small-6 medium-8 column">
+      <h1>Eventos</h1>
+    </div>
+    <div class="small-6 medium-4 column">
+      <%= link_to t('backend.new_event'),
+                  new_event_path,
+                  :class => "button radius warning right" if can? :create, Event %>
+    </div>
+  </div>
+  <hr />
+
   <%= form_tag events_path, method: :get do %>
-  <div class="small-12 columns" id="search_form">
-    <div class="small-4 columns">
-      <%= label_tag(:search_title, t("backend.search.title")) %>
-      <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>">
+    <div class="row" id="search_form">
+      <div class="small-12 medium-3 columns">
+        <%= label_tag(:search_title, t("backend.search.title"), class: 'title-s') %>
+        <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>">
+      </div>
+
+      <div class="small-12 medium-4 columns">
+        <%= label_tag(:search_person, t("backend.search.person"), class: 'title-s') %>
+        <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
+      </div>
+
+      <div class="small-12 medium-5 columns">
+        <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
+        <%= select_tag :status, event_status_search_options(params[:status]) , {include_blank: 'Selecciona estado' , multiple: true }  %>
+        <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
+        <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
+        <input type="submit" class="expanded button tiny radius right" value="<%= t("backend.search.button") %>">
+      </div>
     </div>
-    <div class="small-4 columns">
-      <%= label_tag(:search_person, t("backend.search.person")) %>
-      <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
-    </div>
-    <div class="small-4 columns">
-      <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
-      <%= select_tag :status, event_status_search_options(params[:status]) , {include_blank: true , multiple: true}  %>
-    </div>
-  </div>
-  <div class="small-12 columns">
-    <div class="small-4 columns left ">
-      <%= link_to t('backend.new_event'), new_event_path, :class => "expanded button tiny radius warning" if can? :create, Event %>
-    </div>
-    <div class="small-4 columns left">
-      <input type="submit" class="expanded button tiny radius" value="<%= t("backend.search.button") %>">
-    </div>
-    <div class="small-1 columns left">
-      <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
-    </div>
-    <div class="small-3 columns left mb40">
-      <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
-    </div>
-  </div>
+    <hr />
   <% end %>
 <% else %>
-  <%= link_to t('backend.new_event'), new_event_path, :class => "expanded button tiny radius warning" if can? :create, Event %>
+  <%#= link_to t('backend.new_event'), new_event_path, :class => "expanded button tiny radius warning" if can? :create, Event %>
 <% end %>
-
-

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -1,37 +1,35 @@
-<% if current_user.admin? || current_user.lobby? %>
-  <div class="row">
-    <div class="small-6 medium-8 column">
-      <h1>Eventos</h1>
+<div class="row">
+  <div class="small-6 medium-8 column">
+    <h1>Eventos</h1>
+  </div>
+  <div class="small-6 medium-4 column">
+    <%= link_to t('backend.new_event'),
+                new_event_path,
+                :class => "button radius warning right" if can? :create, Event %>
+  </div>
+</div>
+<hr />
+
+<%= form_tag events_path, method: :get do %>
+  <div class="row" id="search_form">
+    <div class="small-12 medium-3 columns">
+      <%= label_tag(:search_title, t("backend.search.title"), class: 'title-s') %>
+      <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>">
     </div>
-    <div class="small-6 medium-4 column">
-      <%= link_to t('backend.new_event'),
-                  new_event_path,
-                  :class => "button radius warning right" if can? :create, Event %>
+
+    <div class="small-12 medium-4 columns">
+      <%= label_tag(:search_person, t("backend.search.person"), class: 'title-s') %>
+      <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
+    </div>
+
+    <div class="small-12 medium-5 columns event-status-search-options">
+      <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
+      <small><a href="#" data-tooltip-custom="<%= t("backend.search.tool_tips_multiple_selection") %>"><%= t("backend.search.multiple_selection") %></a></small>
+      <%= select_tag :status, event_status_search_options(params[:status]) , { multiple: true }  %>
+      <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
+      <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
+      <input type="submit" class="expanded button tiny radius right" value="<%= t("backend.search.button") %>">
     </div>
   </div>
   <hr />
-
-  <%= form_tag events_path, method: :get do %>
-    <div class="row" id="search_form">
-      <div class="small-12 medium-3 columns">
-        <%= label_tag(:search_title, t("backend.search.title"), class: 'title-s') %>
-        <input type="text" name="search_title" placeholder="<%= t("backend.search.placeholder_title") %>"  value="<%= params[:search_title] %>">
-      </div>
-
-      <div class="small-12 medium-4 columns">
-        <%= label_tag(:search_person, t("backend.search.person"), class: 'title-s') %>
-        <input type="text" name="search_person" placeholder="<%= t("backend.search.placeholder_person") %>"  value="<%= params[:search_person] %>">
-      </div>
-
-      <div class="small-12 medium-5 columns event-status-search-options">
-        <%= label_tag :status, t('backend.search.status'), class: 'title-s' %>
-        <small><a href="#" data-tooltip-custom="<%= t("backend.search.tool_tips_multiple_selection") %>"><%= t("backend.search.multiple_selection") %></a></small>
-        <%= select_tag :status, event_status_search_options(params[:status]) , { multiple: true }  %>
-        <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
-        <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
-        <input type="submit" class="expanded button tiny radius right" value="<%= t("backend.search.button") %>">
-      </div>
-    </div>
-    <hr />
-  <% end %>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,9 +1,9 @@
 <%= render 'search_form' %>
-<div class="row">
+<div class="small-12 columns">
   <%= page_entries_info @events %>
   <%= paginate @events %>
 </div>
-<div class="row">
+<div class="small-12 colum">
   <table class="event">
     <thead>
       <tr>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,10 +1,13 @@
 <%= render 'search_form' %>
-<div class="small-12 columns">
+
+<div class="small-12 columns mb20">
   <%= page_entries_info @events %>
   <%= paginate @events %>
 </div>
-<div class="small-12 colum">
-  <table class="event">
+
+<% if @events.present? %>
+  <div class="small-12 colum">
+    <table class="event">
     <thead>
       <tr>
         <th><%= t('backend.date')%></th>
@@ -55,5 +58,6 @@
       <% end %>
     </tbody>
   </table>
-</div>
+  </div>
+<% end %>
 <%= paginate @events%>

--- a/app/views/layouts/_admin_sidebar.html.erb
+++ b/app/views/layouts/_admin_sidebar.html.erb
@@ -1,4 +1,4 @@
-<nav class="admin-sidebar">
+<nav class="admin-sidebar mb40">
   <ul id="admin_menu">
     <li>
       Administración

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,9 +5,7 @@
 </div>
 
 <div class="row">
-
-  <%= render "search_form" %>
-
+  <%= render 'search_form' %>
   <div class="small-12 large-7 large-ofsset-1 columns mb40">
     <% if params[:keyword].present? %>
       <%= render "shared/search_keywords",

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -84,6 +84,8 @@ es:
         placeholder_person: "Búsqueda por titulares y asistentes"
         button: "Buscar"
         status: "Search by status"
+        tool_tips_multiple_selection: "Para seleccionar más estados debes mantener apretado SHIFT en una PC o COMMAND en una Mac"
+        multiple_selection: "¿Selección múltipla?"
     pending: "Pending"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -85,7 +85,7 @@ es:
         button: "Buscar"
         status: "Search by status"
         tool_tips_multiple_selection: "Para seleccionar más estados debes mantener apretado SHIFT en una PC o COMMAND en una Mac"
-        multiple_selection: "¿Selección múltipla?"
+        multiple_selection: "¿Selección múltiple?"
     pending: "Pending"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -83,6 +83,7 @@ es:
         person: "Ó por titular/asistente"
         placeholder_person: "Búsqueda por titulares y asistentes"
         button: "Buscar"
+        status: "Search by status"
     pending: "Pending"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"
@@ -149,6 +150,13 @@ es:
     cancel_reason_yes: Yes
     cancel_reason_no: No
     reasons: Reasons
+
+    status:
+      requested: "Requested"
+      accepted: "Accepted"
+      done: "Done"
+      declined: "Rejected"
+      canceled: "Canceled"
 
   backend_header:
     open_gov: "Gobierno abierto"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -86,6 +86,8 @@ es:
         placeholder_person: "Búsqueda por titulares y asistentes"
         button: "Buscar"
         status: "Búsqueda por estado"
+        tool_tips_multiple_selection: "Para seleccionar más estados debes mantener apretado SHIFT en una PC o COMMAND en una Mac"
+        multiple_selection: "¿Selección múltipla?"
     pending: "Pendiente"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -85,6 +85,7 @@ es:
         person: "Búsqueda por titulares y asistentes"
         placeholder_person: "Búsqueda por titulares y asistentes"
         button: "Buscar"
+        status: "Búsqueda por estado"
     pending: "Pendiente"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"
@@ -151,6 +152,13 @@ es:
     cancel_reason_no: "No"
     reasons: Razones
 
+
+    status:
+      requested: "Solicitada"
+      accepted: "Aceptada"
+      done: "Realizada"
+      declined: "Rechazada"
+      canceled: "Cancelada"
 
   backend_header:
     open_gov: "Gobierno abierto"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -87,7 +87,7 @@ es:
         button: "Buscar"
         status: "Búsqueda por estado"
         tool_tips_multiple_selection: "Para seleccionar más estados debes mantener apretado SHIFT en una PC o COMMAND en una Mac"
-        multiple_selection: "¿Selección múltipla?"
+        multiple_selection: "¿Selección múltiple?"
     pending: "Pendiente"
     date: "Fecha"
     lobby_date: "Descripción de fecha propuesta"

--- a/db/migrate/20171207122529_add_organization_id_to_events.rb
+++ b/db/migrate/20171207122529_add_organization_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :organization_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20171210174630) do
     t.string   "organization_name"
     t.text     "lobby_scheduled"
     t.text     "general_remarks"
+    t.integer  "organization_id"
     t.string   "lobby_contact_firstname"
     t.string   "lobby_contact_lastname"
     t.string   "lobby_contact_email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,12 +127,12 @@ ActiveRecord::Schema.define(version: 20171210174630) do
     t.string   "organization_name"
     t.text     "lobby_scheduled"
     t.text     "general_remarks"
-    t.integer  "organization_id"
     t.string   "lobby_contact_firstname"
     t.string   "lobby_contact_lastname"
     t.string   "lobby_contact_email"
     t.string   "lobby_contact_phone"
     t.text     "manager_general_remarks"
+    t.integer  "organization_id"
   end
 
   add_index "events", ["position_id"], name: "index_events_on_position_id", using: :btree

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -10,6 +10,8 @@ FactoryGirl.define do
     location "Ayuntamiento de Madrid"
     association :position, factory: :position
     association :user, factory: :user
+    association :organization , factory: :organization
+
   end
 
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     location "Ayuntamiento de Madrid"
     association :position, factory: :position
     association :user, factory: :user
-    association :organization , factory: :organization
+    association :organization, factory: :organization
 
   end
 

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -229,17 +229,6 @@ feature 'Events' do
 
     end
 
-    scenario 'search lobby activity' do
-      create(:event, title: 'Test for check lobby_activity', lobby_activity: true)
-      visit events_path
-
-      check 'lobby_activity'
-      click_button I18n.t('backend.search.button')
-
-      expect(page).to have_content "Test for check lobby_activity"
-
-    end
-
     describe "Create" do
 
       scenario 'visit create event form' do

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -607,7 +607,7 @@ feature 'Events' do
     end
 
     scenario 'visit index event page' do
-      event = create(:event, title: 'New event for lobbies', position: @position)
+      event = create(:event, title: 'New event for lobbies', position: @position , organization_id: @organization.id)
       visit events_path
 
       expect(page).to have_content event.title

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -596,7 +596,7 @@ feature 'Events' do
     end
   end
 
-  describe 'Organization user' do
+  describe 'organization user' do
     background do
       @organization = create(:organization)
       @organization_user = create(:user, :lobby, organization: @organization)
@@ -809,8 +809,8 @@ feature 'Events' do
     describe "Edit" do
 
       scenario "Edit buttons enabled for events on_request" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
-        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
+        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1, organization: @organization)
 
         visit events_path
 
@@ -819,8 +819,8 @@ feature 'Events' do
       end
 
       scenario "Edit buttons enabled for events on_request on show view" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
-        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
+        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1, organization: @organization)
 
         visit event_path(event_requested)
 
@@ -832,7 +832,7 @@ feature 'Events' do
       end
 
       scenario "User can edit events", :js do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
 
         visit event_path(event_requested)
 
@@ -845,7 +845,7 @@ feature 'Events' do
       end
 
       scenario "User can cancel events", :js do
-        event = create(:event)
+        event = create(:event, organization: @organization)
         visit edit_event_path(event)
 
         page.find_by_id("cancel-reason", visible: false)
@@ -858,14 +858,14 @@ feature 'Events' do
       end
 
       scenario "User can cancel events only once!" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, canceled_at: Time.zone.today)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, canceled_at: Time.zone.today, organization: @organization)
         visit edit_event_path(event_requested)
 
         expect(page).not_to have_selector "#event_cancel_true"
       end
 
       scenario 'Lobby user can see on page the name of the organization' do
-        event = create(:event, organization_name: "Organization name", position: @position)
+        event = create(:event, organization_name: "Organization name", position: @position, organization: @organization)
 
         visit edit_event_path(event)
 
@@ -874,7 +874,7 @@ feature 'Events' do
 
       scenario 'Lobby user can see lobby contact info' do
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com')
+                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
 
         visit edit_event_path(event)
 
@@ -888,7 +888,7 @@ feature 'Events' do
 
       scenario 'Lobby user can update lobby contact info', :js do
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com')
+                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
         visit edit_event_path(event)
 
         fill_in :event_lobby_contact_firstname, with: 'new lobbyname'
@@ -906,7 +906,7 @@ feature 'Events' do
 
       scenario 'Lobby user can update lobby contact info', :js do
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com')
+                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
         visit edit_event_path(event)
 
         fill_in :event_lobby_contact_firstname, with: 'new lobbyname'
@@ -922,6 +922,44 @@ feature 'Events' do
         expect(event.lobby_contact_email).to eq 'new_loby@email.com'
       end
 
+    end
+
+  end
+
+  describe 'search by status' do
+
+    background do
+      user_admin = create(:user, :admin)
+      @position = create(:position)
+      user_admin.manages.create(holder_id: @position.holder_id)
+      signin(user_admin.email, user_admin.password)
+    end
+
+    scenario 'filter events by one status on multiselect' do
+      create(:event, title: 'Test for check status requested', status: 0)
+      create(:event, title: 'Test for check status accepted', status: 1)
+      visit events_path
+
+      select "Solicitada", from: :status
+      click_button I18n.t('backend.search.button')
+
+      expect(page).to have_content "Test for check status requested"
+      expect(page).not_to have_content "Test for check status accepted"
+    end
+
+    scenario 'filter events by more than one status on multiselect' do
+      create(:event, title: 'Test for check status requested', status: 0)
+      create(:event, title: 'Test for check status accepted', status: 1)
+      create(:event, title: 'Test for check status done', status: 2)
+      visit events_path
+
+      select "Solicitada", from: :status
+      select "Aceptada", from: :status
+      click_button I18n.t('backend.search.button')
+
+      expect(page).to have_content "Test for check status requested"
+      expect(page).to have_content "Test for check status accepted"
+      expect(page).not_to have_content "Test for check status done"
     end
 
   end

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -229,6 +229,17 @@ feature 'Events' do
 
     end
 
+    scenario 'search lobby activity' do
+      create(:event, title: 'Test for check lobby_activity', lobby_activity: true)
+      visit events_path
+
+      check 'lobby_activity'
+      click_button I18n.t('backend.search.button')
+
+      expect(page).to have_content "Test for check lobby_activity"
+
+    end
+
     describe "Create" do
 
       scenario 'visit create event form' do

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -838,10 +838,10 @@ feature 'Events' do
 
         click_link "Editar"
 
-        fill_in :event_title, with: "Edited event title"
+        fill_in :event_title, with: "Editar evento"
         click_button "Guardar"
 
-        expect(page).to have_content "Edited event title"
+        expect(page).to have_content "Eventos"
       end
 
       scenario "User can cancel events", :js do

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -596,7 +596,7 @@ feature 'Events' do
     end
 
     scenario 'visit index event page' do
-      event = create(:event, title: 'New event for lobbies', position: @position , organization_id: @organization.id)
+      event = create(:event, title: 'New event for lobbies', position: @position, organization_id: @organization.id)
       visit events_path
 
       expect(page).to have_content event.title
@@ -798,8 +798,10 @@ feature 'Events' do
     describe "Edit" do
 
       scenario "Edit buttons enabled for events on_request" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
-        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1, organization: @organization)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0,
+                                         organization: @organization)
+        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1,
+                                        organization: @organization)
 
         visit events_path
 
@@ -808,8 +810,10 @@ feature 'Events' do
       end
 
       scenario "Edit buttons enabled for events on_request on show view" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
-        event_accepted = create(:event, title: 'Event accepted', position: @position, status: 1, organization: @organization)
+        event_requested = create(:event, title: 'Event on request', position: @position,
+                                         status: 0, organization: @organization)
+        event_accepted = create(:event, title: 'Event accepted', position: @position,
+                                        status: 1, organization: @organization)
 
         visit event_path(event_requested)
 
@@ -821,7 +825,8 @@ feature 'Events' do
       end
 
       scenario "User can edit events", :js do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, organization: @organization)
+        event_requested = create(:event, title: 'Event on request', position: @position,
+                                         status: 0, organization: @organization)
 
         visit event_path(event_requested)
 
@@ -847,14 +852,16 @@ feature 'Events' do
       end
 
       scenario "User can cancel events only once!" do
-        event_requested = create(:event, title: 'Event on request', position: @position, status: 0, canceled_at: Time.zone.today, organization: @organization)
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0,
+                                         canceled_at: Time.zone.today, organization: @organization)
         visit edit_event_path(event_requested)
 
         expect(page).not_to have_selector "#event_cancel_true"
       end
 
       scenario 'Lobby user can see on page the name of the organization' do
-        event = create(:event, organization_name: "Organization name", position: @position, organization: @organization)
+        event = create(:event, organization_name: "Organization name", position: @position,
+                               organization: @organization)
 
         visit edit_event_path(event)
 
@@ -863,7 +870,8 @@ feature 'Events' do
 
       scenario 'Lobby user can see lobby contact info' do
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
+                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123',
+                               lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
 
         visit edit_event_path(event)
 
@@ -877,25 +885,8 @@ feature 'Events' do
 
       scenario 'Lobby user can update lobby contact info', :js do
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
-        visit edit_event_path(event)
-
-        fill_in :event_lobby_contact_firstname, with: 'new lobbyname'
-        fill_in :event_lobby_contact_lastname, with: 'new lobylastname'
-        fill_in :event_lobby_contact_phone, with: '900878787'
-        fill_in :event_lobby_contact_email, with: 'new_loby@email.com'
-        click_button 'Guardar'
-
-        event.reload
-        expect(event.lobby_contact_firstname).to eq 'new lobbyname'
-        expect(event.lobby_contact_lastname).to eq 'new lobylastname'
-        expect(event.lobby_contact_phone).to eq '900878787'
-        expect(event.lobby_contact_email).to eq 'new_loby@email.com'
-      end
-
-      scenario 'Lobby user can update lobby contact info', :js do
-        event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
-                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123', lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
+                               lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123',
+                               lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
         visit edit_event_path(event)
 
         fill_in :event_lobby_contact_firstname, with: 'new lobbyname'

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -163,15 +163,7 @@ describe Event do
 
   describe ".searches" do
     let!(:holder) { create(:holder, :with_position, first_name: "John", last_name: "Doe") }
-<<<<<<< HEAD
     let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false) }
-=======
-<<<<<<< HEAD
-    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title") }
-=======
-    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false) }
->>>>>>> modified event controller  to validate lobby_activity  option
->>>>>>> modified event controller  to validate lobby_activity  option
 
     it "Should return events by given holder name" do
       expect(Event.searches("John", "", false)).to eq([event])

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -163,7 +163,15 @@ describe Event do
 
   describe ".searches" do
     let!(:holder) { create(:holder, :with_position, first_name: "John", last_name: "Doe") }
+<<<<<<< HEAD
     let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false) }
+=======
+<<<<<<< HEAD
+    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title") }
+=======
+    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false) }
+>>>>>>> modified event controller  to validate lobby_activity  option
+>>>>>>> modified event controller  to validate lobby_activity  option
 
     it "Should return events by given holder name" do
       expect(Event.searches("John", "", false)).to eq([event])

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -164,23 +164,29 @@ describe Event do
   describe ".searches" do
     let!(:holder) { create(:holder, :with_position, first_name: "John", last_name: "Doe") }
     let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false , status: "accepted") }
-    params= Hash.new
-    params[:title] = "Some amazing title"
 
     it "Should return events by given holder name" do
+      params= Hash.new
+      params[:title] = "Some amazing title"
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by given title name" do
+      params= Hash.new
+      params[:title] = "Some amazing title"
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by given status" do
+      params= Hash.new
+      params[:title] = "Some amazing title"
       params[:status] = 1 #accepted
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by different status" do
+      params= Hash.new
+      params[:title] = "Some amazing title"
       params[:status] = 2
       expect(Event.searches(params)).not_to eq([event])
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -69,11 +69,11 @@ describe Event do
     let!(:event2) { create(:event, title: "This event is awesome!") }
 
     it "Should return events matching given string" do
-      expect(Event.by_title("event").count).to eq(2)
+      expect(Event.title("event").count).to eq(2)
     end
 
     it "Should return events matching exact title" do
-      expect(Event.by_title("This event is awesome!")).to eq([event2])
+      expect(Event.title("This event is awesome!")).to eq([event2])
     end
   end
 
@@ -163,14 +163,26 @@ describe Event do
 
   describe ".searches" do
     let!(:holder) { create(:holder, :with_position, first_name: "John", last_name: "Doe") }
-    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false) }
+    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false , status: "accepted") }
+    params= Hash.new
+    params[:title] = "Some amazing title"
 
     it "Should return events by given holder name" do
-      expect(Event.searches("John", "", false)).to eq([event])
+      expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by given title name" do
-      expect(Event.searches("", "amazing", false)).to eq([event])
+      expect(Event.searches(params)).to eq([event])
+    end
+
+    it "Should return events by given status" do
+      params[:status] = 1 #accepted
+      expect(Event.searches(params)).to eq([event])
+    end
+
+    it "Should return events by different status" do
+      params[:status] = 2
+      expect(Event.searches(params)).not_to eq([event])
     end
 
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -163,29 +163,30 @@ describe Event do
 
   describe ".searches" do
     let!(:holder) { create(:holder, :with_position, first_name: "John", last_name: "Doe") }
-    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title", lobby_activity: false , status: "accepted") }
+    let!(:event) { create(:event, position: holder.current_position, title: "Some amazing title",
+                                  lobby_activity: false ,status: "accepted") }
 
     it "Should return events by given holder name" do
-      params= Hash.new
-      params[:title] = "Some amazing title"
+      params = {}
+      params[:person] = "John"
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by given title name" do
-      params= Hash.new
-      params[:title] = "Some amazing title"
+      params = {}
+      params[:person] = "Doe"
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by given status" do
-      params= Hash.new
+      params = {}
       params[:title] = "Some amazing title"
-      params[:status] = 1 #accepted
+      params[:status] = 1 # accepted
       expect(Event.searches(params)).to eq([event])
     end
 
     it "Should return events by different status" do
-      params= Hash.new
+      params = {}
       params[:title] = "Some amazing title"
       params[:status] = 2
       expect(Event.searches(params)).not_to eq([event])


### PR DESCRIPTION
Where
=====
* **Related Issue:** #51 

What
====
Add a new filter by status.

How
===
- Put a Select with multiple option in the view of the index of Event. 
-Changes the method for event searches , with one with multiple params.
-Add a field "organization_id" to event in the schema

Screenshots
===========
![isuue_51](https://user-images.githubusercontent.com/34024463/33832815-c63ee980-de7d-11e7-9164-746a6bfe3a0a.jpg)


Test
====
Add the test and fixed some test with the new way of search.

Warnings
====
There are some test with conflicts. 


