### PR TITLE
Fix deprecation warning when 'rails server' is started

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path("../spring", __FILE__)
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'

--- a/bin/rake
+++ b/bin/rake
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path("../spring", __FILE__)
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path("../spring", __FILE__)
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require 'bundler/setup'
 load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -4,12 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem "spring", match[1]
-    require "spring/binstub"
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end


### PR DESCRIPTION
Where
=====
* **Related PR's:** #40, #48 

What
====
* Update Rails binaries to solve deprecation warning when starting `rails server`

How
===
* Modified `rails`, `rake`, `rspec` and `spring` binaries based on a personal, up-to-date Rails project
