### PR TITLE
add validation by Agents to lobby event

### DIFF
--- a/app/assets/javascripts/events.js.erb
+++ b/app/assets/javascripts/events.js.erb
@@ -7,6 +7,16 @@ $(function(){
     weekStart: 1
   });
 
+  $.validator.addMethod("valueNotEquals", function(value, element, arg){
+    agent = $("#new_event_agent > div > div.small-12.medium-6.columns > select").val();
+    if ($(element).is(':checked') && (agent == '' ||
+      typeof(agent) == 'undefined' ||
+      agent == "<%= I18n.translate('backend.event.not_available_agents')%>" ))
+      {return false }
+    else
+      { return true }
+  }, "<%= I18n.translate('backend.event.event_agent_needed')%>");
+
   $(".admin-form").validate({
 
       ignore: [],
@@ -25,9 +35,6 @@ $(function(){
           "event[position_id]" : {
               required : true
           },
-          "event[lobby_activity]" : {
-              required : true,
-          },
           "event[attachments_attributes][0][title]" : {
               required : true
           },
@@ -36,6 +43,9 @@ $(function(){
           },
           "event[attachments_attributes][0][public]" : {
             required : true
+          },
+          "event[lobby_activity]" : {
+            valueNotEquals: "<%= I18n.translate('backend.event.not_available_agents')%>"
           },
           "event[published_at]" : {
             required : true
@@ -69,6 +79,9 @@ $(function(){
           },
           "event[published_at]" : {
             required : "<%= I18n.translate('backend.mandatory_field')%>"
+          },
+          "event[event_agents_attributes][0][name]" : {
+            valueNotEquals: "<%= I18n.translate('backend.event.event_agent_needed')%>"
           }
       },
 
@@ -173,7 +186,7 @@ function fill_agents_select_options() {
             }
           });
         }else {
-          select.append($('<option>', { value: "No hay agentes disponibles.", text: "No hay agentes disponibles." }));
+          select.append($('<option>', { value: "<%= I18n.translate('backend.event.not_available_agents')%>", text: "<%= I18n.translate('backend.event.not_available_agents')%>" }));
           id_select_agent = $('#nested-event-agents select').attr('id');
           set_option = $('select#' + id_select_agent + ' option').last().val();
           $('#nested-event-agents select').val(set_option);

--- a/app/models/concerns/event_agent_existence_validator.rb
+++ b/app/models/concerns/event_agent_existence_validator.rb
@@ -1,0 +1,7 @@
+class EventAgentExistenceValidator < ActiveModel::Validator
+  def validate(record)
+    if record.lobby_activity && record.event_agents.empty?
+      record.errors.add(:event_agents, I18n.translate('backend.event.event_agent_needed'))
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,6 +13,7 @@ class Event < ActiveRecord::Base
   validates :title, :position, :location, presence: true
   validates_inclusion_of :lobby_activity, :in => [true, false]
   validate :participants_uniqueness, :position_not_in_participants, :role_validate_published_at, :role_validate_scheduled
+  validates_with EventAgentExistenceValidator
 
   before_create :set_status
   before_save :cancel_event

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
     <thead>
       <tr>
         <th><%= t('backend.date')%></th>
-        <th><%= t('backend.event')%></th>
+        <th><%= t('backend.event.title')%></th>
         <th><%= t('backend.holder')%></th>
         <th><%= t('backend.actions')%></th>
       </tr>
@@ -16,7 +16,7 @@
     <tfoot>
       <tr>
         <th><%= t('backend.date')%></th>
-        <th><%= t('backend.event')%></th>
+        <th><%= t('backend.event.title')%></th>
         <th><%= t('backend.holder')%></th>
         <th><%= t('backend.actions')%></th>
       </tr>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -70,10 +70,13 @@ es:
     must_have_position: "Es necesario añadir al menos un cargo"
 
     events: "Eventos"
-    event: "Evento"
     event_history_updates: "Última actualización"
     event_update_user: "Usuario"
     event_update_date: "Fecha"
+    event:
+      title: 'Event'
+      event_agent_needed: "There should be at least one agent on lobby events"
+      not_available_agents: "Not available agents."
     search:
         title: "Búsqueda por título"
         placeholder_title: "Búsqueda por título"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -72,10 +72,13 @@ es:
     must_have_position: "Es necesario añadir al menos un cargo"
 
     events: "Eventos"
-    event: "Evento"
     event_history_updates: "Última actualización"
     event_update_user: "Usuario"
     event_update_date: "Fecha"
+    event:
+      title: "Evento"
+      event_agent_needed: "En los eventos de lobbies hace falta, al menos, un agente."
+      not_available_agents: "No hay agentes disponibles."
     search:
         title: "Búsqueda por título"
         placeholder_title: "Búsqueda por título"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,11 +4,12 @@ FactoryGirl.define do
   factory :event do
     title "Event title"
     description "Event description"
-    lobby_activity true
-    published_at Date.yesterday
+    lobby_activity false
+    published_at Date.current
     scheduled Time.now
     location "Ayuntamiento de Madrid"
     association :position, factory: :position
     association :user, factory: :user
   end
+
 end

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -51,7 +51,10 @@ feature 'Event page' do
   end
 
   scenario 'search lobby activity for visitors ', :search do
-    create(:event, title: 'Test for check lobby_activity for visitors', lobby_activity: true)
+    event = create(:event, title: 'Test for check lobby_activity for visitors')
+    event.lobby_activity = true
+    event.event_agents << create(:event_agent)
+    event.save!
 
     visit root_path
     check 'lobby_activity'
@@ -59,6 +62,5 @@ feature 'Event page' do
 
     expect(page).to have_content "Test for check lobby_activity for visitors"
   end
-
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/agendas/issues/121

What
====
- Add validation to event. Now requires at least 1 EventAgent if lobby_activity is set to true

How
===
- Added validation in model and updated jquery validator for events/_form.html.erb (events.js.erb)


Screenshots
===========
![screenshot from 2017-12-12 09 06 52](https://user-images.githubusercontent.com/33748390/33873580-d5937b32-df1b-11e7-96e5-1b37526fba0b.png)

Test
====
- Changed tests because now lobby_event requires EventAgent and it stops fitting in the definition of some of them