### PR TITLE
Add a new option for display just Organizations with a Event with Lob…

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -24,6 +24,7 @@ class OrganizationsController < ApplicationController
         fulltext params[:keyword] if params[:keyword].present?
         with(:interest_ids, params[:interests]) if params[:interests].present?
         with(:category_id, params[:category]) if params[:category].present?
+        with(:lobby_activity, true) if params[:lobby_activity].present?
         any do
           fulltext(params[:agent_name], :fields => [:agent_name]) if params[:agent_name].present?
           fulltext(params[:agent_name], :fields => [:agent_first_surname]) if params[:agent_name].present?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -95,6 +95,7 @@ class Event < ActiveRecord::Base
     time :scheduled
     boolean :lobby_activity
     date :published_at
+    integer :organization_id
 
     text :area_title do
       self.position.area.title

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,6 +36,7 @@ class Organization < ActiveRecord::Base
     end
     integer :category_id
     integer :id
+    join(:lobby_activity,:target => Event, :type => :boolean, :join => { :from => :organization_id, :to => :id})
     join(:name, :prefix => "agent", :target => Agent, :type => :text, :join => { :from => :organization_id, :to => :id })
     join(:first_surname, :prefix => "agent", :target => Agent, :type => :text, :join => { :from => :organization_id, :to => :id })
     join(:second_surname, :prefix => "agent", :target => Agent, :type => :text, :join => { :from => :organization_id, :to => :id })

--- a/app/views/organizations/_search_form.html.erb
+++ b/app/views/organizations/_search_form.html.erb
@@ -27,7 +27,14 @@
                      prompt: t("main.form.filter_by"),
                      class: "dropdown" %>
     </div>
-
+    <div class="row">
+      <div class="small-1 columns center">
+        <%= check_box_tag(:lobby_activity, value = "1", checked = check_filter_lobby_activity , id: "lobby_activity")%>
+      </div>
+      <div class="small-11 columns right">
+        <%= label_tag(:lobby_activity, t("backend.lobby_activity")) %>
+      </div>
+    </div>
     <div class="mb20">
       <%= text_field_tag :agent_name, params[:agent_name], placeholder: t("main.form.agent") %>
     </div>

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -161,6 +161,29 @@ feature 'Organizations page' do
       end
     end
 
+  scenario "Should display organizations with event with lobby_activity", :search do
+        organization_one = create(:organization, entity_type: :lobby, name: "Organizacion 1")
+        organization_two = create(:organization, entity_type: :lobby, name: "No lobby activity")
+        event=create(:event,organization: organization_one)
+        event.lobby_activity = true
+        event.event_agents << create(:event_agent)
+        event.save!
+        event_two = create(:event, lobby_activity: false, organization: organization_two)
+        event_two.lobby_activity = false
+        event_two.event_agents << create(:event_agent)
+        event_two.save!
+        Organization.reindex
+
+        visit organizations_path
+
+        find(:css, "#lobby_activity[value='1']").set(true)
+        click_button(I18n.t('main.form.search'))
+
+        expect(page).to have_content "Organizacion 1"
+        expect(page).not_to have_content "No lobby activity"
+  end
+
+
     scenario 'Should be go to show page when click on organization', :search do
       organization = create(:organization)
       Organization.reindex


### PR DESCRIPTION
…by Activity

Where
=====
* **Related Issue:** #137 

What
====
- Create a new option for Organizations with Events with lobby activity

How
===
- New check box to filter just the orgazations wiht Events with lobby activity

Screenshots
===========
![issue_137](https://user-images.githubusercontent.com/34024463/33933560-65678674-dff6-11e7-8744-fc944016879f.jpg)


Test
====
- Added new test to covert the option

