### PR TITLE
Manage user can set status event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ end
 
 group :test do
   gem 'capybara', '~> 2.5.0'
+  gem 'capybara-email', '~> 2.5.0'
   gem 'coveralls', require: false
   gem 'database_cleaner', '~> 1.5.0'
   gem 'launchy', '~> 2.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.5.0)
+      capybara (~> 2.4)
+      mail
     climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
@@ -467,6 +470,7 @@ DEPENDENCIES
   capistrano-rails-console
   capistrano-rvm (~> 0.1.1)
   capybara (~> 2.5.0)
+  capybara-email (~> 2.5.0)
   cocoon (~> 1.2.6)
   coffee-rails (~> 4.1.0)
   coveralls

--- a/app/assets/javascripts/events.js.erb
+++ b/app/assets/javascripts/events.js.erb
@@ -1,4 +1,10 @@
 $(function(){
+  $('#decline_link').bind('click', function(e){
+    e.preventDefault();
+    $('#decline_link').hide();
+    $('#decline-reason').show();
+  });
+
   $('.fdatepicker').fdatepicker({
     format: "<%= I18n.translate('datepicker-format-time') %>",
     pickTime: true,
@@ -12,6 +18,17 @@ $(function(){
     if ($(element).is(':checked') && (agent == '' ||
       typeof(agent) == 'undefined' ||
       agent == "<%= I18n.translate('backend.event.not_available_agents')%>" ))
+      {return false }
+    else
+      { return true }
+  }, "<%= I18n.translate('backend.event.event_agent_needed')%>");
+
+
+  $.validator.addMethod("checkMessage", function(value, element, arg){
+    tinyMCE.triggerSave();
+    id = "#event_" + arg
+    content = $(id).val();
+    if ($(element).is(':checked') && (content == ''))
       {return false }
     else
       { return true }
@@ -49,6 +66,12 @@ $(function(){
           },
           "event[published_at]" : {
             required : true
+          },
+          "event[decline]" : {
+            checkMessage : "declined_reasons"
+          },
+          "event[cancel]" : {
+            checkMessage : "reasons"
           }
       },
 
@@ -82,12 +105,22 @@ $(function(){
           },
           "event[event_agents_attributes][0][name]" : {
             valueNotEquals: "<%= I18n.translate('backend.event.event_agent_needed')%>"
+          },
+          "event[decline]" : {
+            checkMessage : "<%= I18n.translate('backend.event.decline_reasons_needed')%>"
+          },
+          "event[cancel]" : {
+            checkMessage : "<%= I18n.translate('backend.event.reasons_needed')%>"
           }
       },
 
       errorPlacement : function(error, element) {
         error.insertAfter(element);
-        if (element.attr("name") == "event[lobby_activity]" ){
+        if (element.attr("name") == "event[cancel]" ){
+          error.appendTo('.cancel-reason-activity .error-radio-buttons');
+        } else if (element.attr("name") == "event[decline]" ){
+          error.appendTo('.decline-reason-activity .error-radio-buttons');
+        } else if (element.attr("name") == "event[lobby_activity]" ){
           error.appendTo('.meeting-lobby-activity .error-radio-buttons');
         } else if (element.attr("name") == "event[attachments_attributes][0][public]" ) {
           error.appendTo('.attachments-public .error-radio-buttons');
@@ -141,6 +174,20 @@ $(function(){
 
   $("#event_cancel_false").click(function(){
     $("#cancel-reason").hide();
+  });
+
+  $('#decline-reason').hide();
+
+  $("#event_decline_true").click(function(){
+    $("#decline-reason").show();
+  });
+
+  if ($("#event_decline_true").is(":checked")) {
+    $("#decline-reason").show();
+  };
+
+  $("#event_decline_false").click(function(){
+    $("#decline-reason").hide();
   });
 
 });

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -45,7 +45,7 @@ class EventsController < AdminController
 
   def event_params
     params.require(:event).permit(:title, :description, :location, :scheduled, :position_id, :search_title, :search_person,
-                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel, :organization_id,
+                                  :lobby_activity, :notes, :status, :reasons, :published_at, :cancel, :decline, :declined_reasons,:organization_id,
                                   :organization_name, :lobby_scheduled, :general_remarks, :lobby_contact_firstname,
                                   :lobby_contact_lastname, :lobby_contact_phone, :lobby_contact_email, :lobby_general_remarks,
                                   event_represented_entities_attributes: [:id, :name, :_destroy],
@@ -89,7 +89,6 @@ class EventsController < AdminController
     person = params[:search_person]
     title = params[:search_title]
     status = enum_status(params[:status])
-    
     params_searches = {}
     params_searches[:title] = title unless title.blank?
     params_searches[:lobby_activity] = "1" unless params[:lobby_activity].blank?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,4 +51,8 @@ module ApplicationHelper
     !event.canceled_at.nil?
   end
 
+  def declined_event(event)
+    !event.declined_at.nil?
+  end
+
 end

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -10,4 +10,14 @@ class EventMailer < ApplicationMailer
     mail(to: user.email, subject: subject)
   end
 
+  def decline(event)
+    @lobby_name = event.lobby_user_name
+    @reasons = event.declined_reasons
+    @event_title = event.title
+    @name = event.user.full_name
+    @declined_at = l event.declined_at, format: :short
+    subject = t('mailers.decline_event.subject', title: @event_title)
+    mail(to: event.lobby_contact_email, subject: subject)
+  end
+
 end

--- a/app/views/event_mailer/decline.erb
+++ b/app/views/event_mailer/decline.erb
@@ -1,0 +1,25 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+  <h1 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;">
+    <%= t('mailers.decline_event.welcome', name: @lobby_name) %>
+  </h1>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+     <%= t('mailers.decline_event.text1', title: @event_title) %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+     <%= t('mailers.decline_event.text2', name: @name) %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+     <%= raw @reasons %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+     <%= t('mailers.decline_event.declined_at', declined_at: @declined_at) %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t('mailers.decline_event.thanks') %>
+  </p>
+</td>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -180,36 +180,61 @@
       </div>
     </fieldset>
 
-    <fieldset class="cancel-reason-activity">
-      <% canceled_event = canceled_event(f.object) %>
-      <% if canceled_event %>
-        <legend><%= t('backend.canceled_event') %></legend>
-        <% unless f.object.reasons.blank? %>
-          <%= f.label :reasons, t('backend.reasons') %>
-          <br/>
-          <%= raw f.object.reasons %>
-        <% end  %>
-      <% else %>
-        <legend><%= t('backend.cancel_event') %></legend>
-        <%= f.radio_button :cancel, true, checked: canceled_event %>
-        <%= f.label :cancel, t('backend.cancel_reason_yes'), value: true %>
-        <%= f.radio_button :cancel, false, checked: !canceled_event %>
-        <%= f.label :cancel, t('backend.cancel_reason_no'), value: false %>
-        <div class="small-12 error-radio-buttons"></div>
-        <div id="cancel-reason" style="display: none">
-          <div class="row">
-            <div class="small-12 columns">
-              <%= f.label :reasons, t('backend.reasons') %>
-              <%= f.text_area :reasons, class: 'tinymce' %>
+    <% if f.object.user != current_user %>
+      <fieldset class="cancel-reason-activity">
+        <% canceled_event = canceled_event(f.object) %>
+        <% if canceled_event %>
+          <legend><%= t('backend.canceled_event') %></legend>
+          <% unless f.object.reasons.blank? %>
+            <%= f.label :reasons, t('backend.reasons') %>
+            <br/>
+            <%= raw f.object.reasons %>
+          <% end  %>
+        <% else %>
+          <legend><%= t('backend.cancel_event') %></legend>
+          <%= f.radio_button :cancel, true, checked: canceled_event %>
+          <%= f.label :cancel, t('backend.cancel_reason_yes'), value: true %>
+          <%= f.radio_button :cancel, false, checked: !canceled_event %>
+          <%= f.label :cancel, t('backend.cancel_reason_no'), value: false %>
+          <div class="small-12 error-radio-buttons"></div>
+          <div id="cancel-reason" style="display: none">
+            <div class="row">
+              <div class="small-12 columns">
+                <%= f.label :reasons, t('backend.reasons') %>
+                <%= f.text_area :reasons, class: 'tinymce' %>
+              </div>
             </div>
           </div>
-        </div>
-      <% end %>
-    </fieldset>
+        <% end %>
+      </fieldset>
+
+      <fieldset class="decline-reason-activity">
+        <% declined_event = declined_event(f.object) %>
+        <% if declined_event %>
+          <legend><%= t('backend.declined_event') %></legend>
+          <%= f.label :reasons, t('backend.reasons') %>
+          <br/>
+          <%= raw f.object.declined_reasons %>
+        <% else %>
+          <legend><%= t('backend.decline_event') %></legend>
+          <%= f.radio_button :decline, true, checked: declined_event %>
+          <%= f.label :decline, t('backend.decline_reason_yes'), value: true %>
+          <%= f.radio_button :decline, false, checked: !declined_event %>
+          <%= f.label :decline, t('backend.decline_reason_no'), value: false %>
+          <div class="small-12 error-radio-buttons"></div>
+          <div id="decline-reason" style="display: none">
+            <div class="row">
+              <div class="small-12 columns">
+                <%= f.label :declined_reasons, t('backend.reasons') %>
+                <%= f.text_area :declined_reasons, class: 'tinymce' %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </fieldset>
+    <% end %>
 
   <%= submit_tag t('backend.save'), :class=> "button radius success right" %>
 <% end %>
-
-
 
 <%= javascript_include_tag 'events'%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,4 +41,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -79,6 +79,8 @@ es:
       title: 'Event'
       event_agent_needed: "There should be at least one agent on lobby events"
       not_available_agents: "Not available agents."
+      reasons_needed: "You must provide some reasons to cancel the event"
+      decline_reasons_needed: "You must provide some reasons to decline the event"
     search:
         title: "Búsqueda por título"
         placeholder_title: "Búsqueda por título"
@@ -154,13 +156,16 @@ es:
     cancel_reason_yes: Yes
     cancel_reason_no: No
     reasons: Reasons
-
     status:
       requested: "Requested"
       accepted: "Accepted"
       done: "Done"
       declined: "Rejected"
       canceled: "Canceled"
+    decline_event: Decline evento
+    declined_event: Event declined
+    decline_reason_yes: Yes
+    decline_reason_no: No
 
   backend_header:
     open_gov: "Gobierno abierto"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -81,6 +81,8 @@ es:
       title: "Evento"
       event_agent_needed: "En los eventos de lobbies hace falta, al menos, un agente."
       not_available_agents: "No hay agentes disponibles."
+      reasons_needed: "Debe dar alguna razon para cancelar el evento"
+      decline_reasons_needed: "Debe dar alguna razon para declinar el evento"
     search:
         title: "Búsqueda por título"
         placeholder_title: "Búsqueda por título"
@@ -155,14 +157,16 @@ es:
     cancel_reason_yes: Si
     cancel_reason_no: "No"
     reasons: Razones
-
-
     status:
       requested: "Solicitada"
       accepted: "Aceptada"
       done: "Realizada"
       declined: "Rechazada"
       canceled: "Cancelada"
+    decline_event: Declinar evento
+    declined_event: Evento declinado
+    decline_reason_yes: Si
+    decline_reason_no: "No"
 
   backend_header:
     open_gov: "Gobierno abierto"

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -7,3 +7,10 @@ en:
       text2: "Has been cancelled for the following reason:"
       canceled_at: "On %{canceled_at}"
       thanks: "Regards"
+    decline_event:
+      subject: "Declined event: %{title}"
+      welcome: "Hello %{name}"
+      text1: "The event: %{title}"
+      text2: "Has been declined by %{name}, for the following reason:"
+      declined_at: "On %{declined_at}"
+      thanks: "Regards"

--- a/config/locales/mailers.es.yml
+++ b/config/locales/mailers.es.yml
@@ -7,3 +7,10 @@ es:
       text2: "Ha sido cancelado por la siguiente razón:"
       canceled_at: "A día %{canceled_at}"
       thanks: "Un saludo"
+    decline_event:
+      subject: "Declinado evento: %{title}"
+      welcome: "Hola %{name}"
+      text1: "El evento: %{title}"
+      text2: "Ha sido declinado por %{name}, por la siguiente razón:"
+      declined_at: "A día %{declined_at}"
+      thanks: "Un saludo"

--- a/db/migrate/20171213141703_add_declinded_to_event.rb
+++ b/db/migrate/20171213141703_add_declinded_to_event.rb
@@ -1,0 +1,6 @@
+class AddDeclindedToEvent < ActiveRecord::Migration
+  def change
+    add_column :events, :declined_at, :date
+    add_column :events, :declined_reasons, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,8 @@ ActiveRecord::Schema.define(version: 20171213171029) do
     t.string   "lobby_contact_phone"
     t.text     "manager_general_remarks"
     t.integer  "organization_id"
+    t.date     "declined_at"
+    t.string   "declined_reasons"
   end
 
   add_index "events", ["position_id"], name: "index_events_on_position_id", using: :btree

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -598,7 +598,6 @@ feature 'Events' do
     scenario 'visit index event page' do
       event = create(:event, title: 'New event for lobbies', position: @position, organization_id: @organization.id)
       visit events_path
-
       expect(page).to have_content event.title
     end
 
@@ -845,18 +844,68 @@ feature 'Events' do
         page.find_by_id("cancel-reason", visible: false)
         page.choose('event_cancel_true')
         page.find_by_id("cancel-reason", visible: true)
+        editor = page.find_by_id('cancel-reason')
+        editor.native.send_keys 'test'
 
         click_button "Guardar"
 
         expect(page).not_to have_selector "#event_cancel_true"
       end
 
+      scenario "User can't cancel events without a reason", :js do
+        event = create(:event, organization: @organization)
+        visit edit_event_path(event)
+
+        page.find_by_id("cancel-reason", visible: false)
+        page.choose('event_cancel_true')
+        page.find_by_id("cancel-reason", visible: true)
+
+        click_button "Guardar"
+
+        expect(page).to have_content I18n.t('backend.event.reasons_needed'), count: 1
+      end
+
       scenario "User can cancel events only once!" do
         event_requested = create(:event, title: 'Event on request', position: @position, status: 0,
-                                         canceled_at: Time.zone.today, organization: @organization)
+                                         reasons: 'test', canceled_at: Time.zone.today, organization: @organization)
         visit edit_event_path(event_requested)
 
         expect(page).not_to have_selector "#event_cancel_true"
+      end
+
+      scenario "User can decline events", :js do
+        event = create(:event, organization: @organization)
+        visit edit_event_path(event)
+
+        page.find_by_id("decline-reason", visible: false)
+        page.choose('event_decline_true')
+        page.find_by_id("decline-reason", visible: true)
+        editor = page.find_by_id('decline-reason')
+        editor.native.send_keys 'test'
+
+        click_button "Guardar"
+
+        expect(page).not_to have_selector "#event_decline_true"
+      end
+
+      scenario "User can't decline events without a reason", :js do
+        event = create(:event, organization: @organization)
+        visit edit_event_path(event)
+        page.find_by_id("decline-reason", visible: false)
+        page.choose('event_decline_true')
+        page.find_by_id("decline-reason", visible: true)
+
+        click_button "Guardar"
+
+        expect(page).to have_content I18n.t('backend.event.decline_reasons_needed'), count: 1
+      end
+
+      scenario "User can decline events only once!" do
+        event_requested = create(:event, title: 'Event on request', position: @position, status: 0,
+                                         declined_reasons: 'test', declined_at: Time.zone.today, organization: @organization)
+        visit edit_event_path(event_requested)
+
+        expect(page).not_to have_selector "#event_decline_true"
       end
 
       scenario 'Lobby user can see on page the name of the organization' do

--- a/spec/features/mailers/events_mailer_spec.rb
+++ b/spec/features/mailers/events_mailer_spec.rb
@@ -1,0 +1,40 @@
+feature 'Events Mailer' do
+
+  describe "Cancel Event" do
+
+    background do
+      clear_emails
+      @event = create(:event, title: 'New event from Capybara', user: create(:user))
+      @event.cancel = 'true'
+      @event.reasons = 'test'
+      @event.save!
+      open_email(@event.user.email)
+    end
+
+    scenario 'cancel event mail' do
+      expect(current_email).to have_content I18n.t('mailers.cancel_event.text1', title: @event.title)
+    end
+
+  end
+
+  describe "Decline Event" do
+
+    background do
+      clear_emails
+      @event = create(:event, title: 'New event from Capybara',
+        user: create(:user, :lobby))
+      @event.lobby_contact_firstname = 'test_name'
+      @event.lobby_contact_lastname = 'test_other_name'
+      @event.lobby_contact_email = 'test_lobby_mail'
+      @event.decline = 'true'
+      @event.declined_reasons = 'test'
+      @event.save!
+      open_email(@event.lobby_contact_email)
+    end
+
+    scenario 'decline event mail' do
+      expect(current_email).to have_content I18n.t('mailers.decline_event.text1', title: @event.title)
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'coveralls'
 Coveralls.wear!('rails')
 require 'simplecov'
+require 'capybara/email/rspec'
 
 SimpleCov.start
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/agendas/issues/133

What
====
- Add decline to events 
- Add setup for mail testing
- Add gem for check mails on development

How
===
- How you implemented/achieved the objective ?

Screenshots
===========
![screenshot from 2017-12-14 13 34 59](https://user-images.githubusercontent.com/33748390/33992625-ace25b54-e0d3-11e7-97bc-f192261c1fa5.png)
![screenshot from 2017-12-14 13 35 14](https://user-images.githubusercontent.com/33748390/33992626-ad7f2d9e-e0d3-11e7-9271-a7ba98b07476.png)
![screenshot from 2017-12-14 13 35 25](https://user-images.githubusercontent.com/33748390/33992627-adb09410-e0d3-11e7-867d-c7ec52b8245a.png)


Test
====
- I have increased the tests to cover the new features and aditionally added more test for cancel event mail