### PR TITLE
add owned events to organizations show

### DIFF
--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -212,5 +212,22 @@
             </ul>
         </div>
       </li>
+      <li class="accordion-navigation">
+        <a href="#panel8">
+          <%= t('organizations.show.events_title') %>
+          <span class="fa accordion-icon"></span>
+        </a>
+          <div id="panel8" class="content">
+            <ul>
+              <% if @organization.events.each do |event| %>
+                <li>
+                  <p><%= link_to event.title, event_path(event) %></p>
+                </li>
+              <% end.empty? %>
+                <%= t('organizations.show.no_results') %>
+              <% end %>
+            </ul>
+        </div>
+      </li>
     </ul>
 </div>

--- a/config/locales/organizations.en.yml
+++ b/config/locales/organizations.en.yml
@@ -55,6 +55,8 @@ en:
 
       interests_title: "Area de interés"
 
+      events_title: "Events"
+
     new:
       title: Registration in lobbies
 

--- a/config/locales/organizations.es.yml
+++ b/config/locales/organizations.es.yml
@@ -62,7 +62,9 @@ es:
       agents_to: "Fecha de fin de representación"
 
       interests_title: "Area de interés"
-      
+
+      events_title: "Eventos"
+
     new:
       title: Alta en el registro de lobbies
 
@@ -71,7 +73,7 @@ es:
 
     delete:
       title: Baja en el registro de lobbies
-      
+
   backend:
     new_organization_title: "Nueva organización"
     reference:

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -363,6 +363,19 @@ feature 'Organizations page' do
       expect(page).to have_content interest2.name
     end
 
+    scenario "Should display organization event" do
+      organization = create(:organization)
+      event1 = create(:event)
+      event2 = create(:event)
+      organization.events << event1
+      organization.events << event2
+
+      visit organization_path(organization)
+
+      expect(page).to have_content event1.title
+      expect(page).to have_content event2.title
+    end
+
     scenario "Should return to organizations index page" do
       organization = create(:organization)
       visit organization_path(organization)


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/agendas/issues/151

What
====
- Add links to owned events from organization_show

Screenshots
===========
![screenshot from 2017-12-14 14 16 14](https://user-images.githubusercontent.com/33748390/33994068-5deedb8e-e0d9-11e7-98e4-e01348d45b4a.png)
