### PR TITLE
Autocomplete option for Lobby user in Events section Holders

### DIFF
--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -3,7 +3,7 @@ class PositionsController < AdminController
   autocomplete :position, :title, display_value: :full_name
 
   def get_autocomplete_items(parameters)
-    	items = Position.full_like("%#{parameters[:term]}%")
+    items = Position.full_like("%#{parameters[:term]}%")
   end
 
 end

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -1,0 +1,9 @@
+class PositionsController < AdminController
+
+  autocomplete :position, :title, display_value: :full_name
+
+  def get_autocomplete_items(parameters)
+    	items = Position.full_like("%#{parameters[:term]}%")
+  end
+
+end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -58,7 +58,7 @@ module Admin
       options_for_select(rev, selected)
     end
 
-    def holder_name_by_position_id (position_id)
+    def holder_name_by_position_id(position_id)
       holder_title = Position.find(position_id).full_name if position_id.present?
     end
   end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -57,5 +57,9 @@ module Admin
       t("backend.status").each_with_index { |(k, v)| rev[v] = k }
       options_for_select(rev, selected)
     end
+
+    def holder_name_by_position_id (position_id)
+      holder_title = Position.find(position_id).full_name if position_id.present?
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ActiveRecord::Base
   include PublicActivity::Model
 
   attr_accessor :cancel, :decline
+  attr_accessor :holder_title
 
   tracked owner: Proc.new { |controller, model| controller.present? ? controller.current_user : model.user }
   tracked title: Proc.new { |controller, model| controller.present? ? controller.get_title : model.title }

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -7,11 +7,10 @@ class Position < ActiveRecord::Base
   has_many :participants_events, through: :participants
 
   validates :title, :area, presence: true
-
   scope :current, -> { where(to: nil) }
   scope :previous, -> { where.not(to: nil) }
   scope :area_filtered, ->(area) { where(area_id: Area.find(area).subtree_ids) if area.present? }
-
+  scope :full_like, lambda { |search_name| where("holder_id IN (?)", Holder.by_name(search_name).pluck(:id)) }
   def events
     (titular_events + participants_events).uniq
   end
@@ -25,4 +24,10 @@ class Position < ActiveRecord::Base
     holder_ids = Holder.managed_by(user_id).ids
     Position.where(holder_id: holder_ids)
   end
+
+  def full_name
+    holder = Holder.where(id: self.holder_id).first
+    (holder.last_name.to_s.delete(',') + ', ' + holder.first_name.to_s.delete(',') + ' - ' + self.title).mb_chars.to_s
+  end
+
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -10,7 +10,7 @@ class Position < ActiveRecord::Base
   scope :current, -> { where(to: nil) }
   scope :previous, -> { where.not(to: nil) }
   scope :area_filtered, ->(area) { where(area_id: Area.find(area).subtree_ids) if area.present? }
-  scope :full_like, lambda { |search_name| where("holder_id IN (?) OR title ILIKE ?", Holder.by_name(search_name).pluck(:id) , "%#{search_name}%" ) }
+  scope :full_like, lambda { |search_name| where("holder_id IN (?) OR title ILIKE ?", Holder.by_name(search_name).pluck(:id), "%#{search_name}%") }
   def events
     (titular_events + participants_events).uniq
   end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -10,7 +10,7 @@ class Position < ActiveRecord::Base
   scope :current, -> { where(to: nil) }
   scope :previous, -> { where.not(to: nil) }
   scope :area_filtered, ->(area) { where(area_id: Area.find(area).subtree_ids) if area.present? }
-  scope :full_like, lambda { |search_name| where("holder_id IN (?)", Holder.by_name(search_name).pluck(:id)) }
+  scope :full_like, lambda { |search_name| where("holder_id IN (?) OR title ILIKE ?", Holder.by_name(search_name).pluck(:id) , "%#{search_name}%" ) }
   def events
     (titular_events + participants_events).uniq
   end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -42,8 +42,14 @@
           <%= f.label :scheduled, t('backend.date') %>
           <%= f.text_field :scheduled, class: 'fdatepicker' %>
         <% end %>
-        <%= f.label :position_id, t('backend.main_position') %>
-        <%= f.select :position_id, @positions.map{|position| [position.holder.full_name_comma+' - '+position.title, position.id]}, prompt: t('backend.select') %>
+        <% if current_user.lobby? %>
+          <%= f.label :name_holder, t('backend.main_position') %>
+          <%= f.autocomplete_field :holder_title,  autocomplete_position_title_positions_path ,:update_elements => {:id => '#position_id'} , placeholder: t('backend.holder_input') , value: holder_name_by_position_id(@event.position_id) %>
+          <%= hidden_field_tag "event[position_id]" , "" , {:id => "position_id"} %>
+        <% else %>
+          <%= f.label :position_id, t('backend.main_position') %>
+          <%= f.select :position_id, @positions.map{|position| [position.holder.full_name_comma+' - '+position.title, position.id]}, prompt: t('backend.select') %>
+        <% end %>
       </div>
     </fieldset>
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -46,6 +46,7 @@ es:
     manage_agendas: "Asignación de Agendas"
     lobby: "Lobby"
     lobby_activity: "Lobby Activity"
+    holder_input: "Search a person by name"
 
     holders: "Titulares"
     holder: "Titular"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -47,6 +47,7 @@ es:
     manage_agendas: "Asignación de Agendas"
     lobby: "Lobby"
     lobby_activity: "Actividad de Lobby"
+    holder_input: "Buscar una persona por nombre"
 
     holders: "Titulares"
     holder: "Titular"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,16 +41,11 @@ Rails.application.routes.draw do
   match 'admin/update_password', to: 'admin/passwords#update', as: 'update_password', via: [:patch, :put]
 
   resources :users
-
   resources :events
-
-  resources :holders
-
   resources :areas
-
   resources :activities
-
   resources :infringement_emails, only: [:new, :create]
+  resources :holders
 
   namespace :admin do
     resources :organizations
@@ -58,6 +53,9 @@ Rails.application.routes.draw do
     post 'order_questions', to: 'questions#order', as: 'order_questions'
   end
 
+  resources :positions do
+    get :autocomplete_position_title, :on => :collection
+  end
   get '/organizations/edit', to: 'organizations#edit', as: 'edit_organization'
   get '/organizations/destroy', to: 'organizations#destroy', as: 'destroy_organization'
   get '/organizations/new', to: 'organizations#new', as: 'new_organization'

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -611,7 +611,7 @@ feature 'Events' do
         expect(page).to have_selector('#event_description')
         expect(page).to have_selector('#event_general_remarks')
         expect(page).to have_selector('#event_lobby_scheduled')
-        expect(page).to have_selector('#position_id' , :visible => false)
+        expect(page).to have_selector('#position_id', :visible => false)
         expect(page).to have_selector('#event_lobby_activity_true')
         expect(page).to have_selector('#event_lobby_activity_false')
         expect(page).to have_selector('#event_lobby_contact_firstname')
@@ -839,7 +839,7 @@ feature 'Events' do
       end
 
       scenario "User can cancel events", :js do
-        event = create(:event, organization: @organization , position: @position)
+        event = create(:event, organization: @organization, position: @position)
         visit edit_event_path(event)
 
         page.find_by_id("cancel-reason", visible: false)

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -611,7 +611,7 @@ feature 'Events' do
         expect(page).to have_selector('#event_description')
         expect(page).to have_selector('#event_general_remarks')
         expect(page).to have_selector('#event_lobby_scheduled')
-        expect(page).to have_selector('#event_position_id')
+        expect(page).to have_selector('#position_id' , :visible => false)
         expect(page).to have_selector('#event_lobby_activity_true')
         expect(page).to have_selector('#event_lobby_activity_false')
         expect(page).to have_selector('#event_lobby_contact_firstname')
@@ -651,7 +651,8 @@ feature 'Events' do
         within('#new_event_agent') do
           select @agent.name
         end
-        select "#{@position.holder.full_name_comma} - #{@position.title}", from: :event_position_id
+        choose_autocomplete :event_position_title, with: @position.title, select: @position.title
+        find("#position_id", :visible => false).set(@position.id)
         click_button I18n.t('backend.save')
 
         expect(page).to have_content 'Registro creado correctamente'
@@ -692,9 +693,9 @@ feature 'Events' do
         within('#new_event_agent') do
           select @agent.name
         end
-        select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
+        choose_autocomplete :event_position_title, with: new_position.title, select: new_position.title
+        find("#position_id", :visible => false).set(new_position.id)
         click_button "Guardar"
-
         event = Event.where(title: "Title").first
         expect(page).to have_content "Registro creado correctamente"
         expect(event.title).to eq "Title"
@@ -838,7 +839,7 @@ feature 'Events' do
       end
 
       scenario "User can cancel events", :js do
-        event = create(:event, organization: @organization)
+        event = create(:event, organization: @organization , position: @position)
         visit edit_event_path(event)
 
         page.find_by_id("cancel-reason", visible: false)
@@ -846,6 +847,7 @@ feature 'Events' do
         page.find_by_id("cancel-reason", visible: true)
         editor = page.find_by_id('cancel-reason')
         editor.native.send_keys 'test'
+        find("#position_id", :visible => false).set(@position.id)
 
         click_button "Guardar"
 
@@ -859,6 +861,7 @@ feature 'Events' do
         page.find_by_id("cancel-reason", visible: false)
         page.choose('event_cancel_true')
         page.find_by_id("cancel-reason", visible: true)
+        find("#position_id", :visible => false).set(@position.id)
 
         click_button "Guardar"
 
@@ -882,6 +885,7 @@ feature 'Events' do
         page.find_by_id("decline-reason", visible: true)
         editor = page.find_by_id('decline-reason')
         editor.native.send_keys 'test'
+        find("#position_id", :visible => false).set(@position.id)
 
         click_button "Guardar"
 
@@ -933,18 +937,23 @@ feature 'Events' do
       end
 
       scenario 'Lobby user can update lobby contact info', :js do
+        position = create(:position)
         event = create(:event, organization_name: "Organization name", lobby_contact_firstname: 'lobbyname',
                                lobby_contact_lastname: 'lobbylastname', lobby_contact_phone: '600123123',
-                               lobby_contact_email: 'lobbyemail@email.com', organization: @organization)
+                               lobby_contact_email: 'lobbyemail@email.com', organization: @organization,
+                               position: position)
         visit edit_event_path(event)
 
         fill_in :event_lobby_contact_firstname, with: 'new lobbyname'
         fill_in :event_lobby_contact_lastname, with: 'new lobylastname'
         fill_in :event_lobby_contact_phone, with: '900878787'
         fill_in :event_lobby_contact_email, with: 'new_loby@email.com'
+        find("#position_id", :visible => false).set(@position.id)
+
         click_button 'Guardar'
 
         event.reload
+
         expect(event.lobby_contact_firstname).to eq 'new lobbyname'
         expect(event.lobby_contact_lastname).to eq 'new lobylastname'
         expect(event.lobby_contact_phone).to eq '900878787'


### PR DESCRIPTION
Where
=====
* **Related Issue:** #131 

What
====
- Autocomplete option for Lobby user in Holder selection

How
===
- Implement an autocomplete field

Screenshots
===========
![issue_131](https://user-images.githubusercontent.com/34024463/34040420-e7e90160-e193-11e7-98d4-ad7d20ff04af.jpg)

Test
====
Fixed test to use the new search option

