### PR TITLE
Add rake task for update event status to done

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,0 +1,10 @@
+namespace :events do
+
+  desc "Update event status to done"
+  task :update_event_status => :environment do
+    Event.where("scheduled <= ? AND status = ?", Date.today, 1).each do |event|
+      event.update(status: :done)
+    end
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #166 

What
====
- We need to update the status of events to :done when they have occurred.

How
===
- Create a rake task to update event status from :accepted to :done when "scheduled" is less or equal to today.

Screenshots
===========
- None

Test
====
- Add specs for rake task  events:update_event_status

Deployment
==========
- A usual.

Warnings
========
- Need add this rake task on cron job related #170 
