### PR TITLE
add filters for events in the user menu

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,6 +2,7 @@ class AdminController < ApplicationController
   include PublicActivity::StoreController
 
   before_action :authenticate_user!
+  before_action :events_root_path
   layout 'admin'
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to admin_path, :alert => t('backend.access_denied')
@@ -11,5 +12,15 @@ class AdminController < ApplicationController
   helper_method :current_user
   hide_action :current_user
   hide_action :get_title
+
+  def events_root_path
+    if current_user.user?
+      @events_path = events_path({"utf8"=>"✓", "search_title"=>"", "search_person"=>"",
+                              "status"=>["requested", "declined"], "lobby_activity"=>"1",
+                              "controller"=>"events", "action"=>"index"})
+    else
+      @events_path = events_path
+    end
+  end
 
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < AdminController
     @event = Event.new(event_params)
     @event.user = current_user
     if @event.save
-      redirect_to events_path, notice: t('backend.successfully_created_record')
+      redirect_to @events_path, notice: t('backend.successfully_created_record')
     else
       flash[:alert] = t('backend.review_errors')
       render :new
@@ -29,7 +29,7 @@ class EventsController < AdminController
   def update
     @event.user = current_user
     if @event.update_attributes(event_params)
-      redirect_to events_path, notice: t('backend.successfully_updated_record')
+      redirect_to @events_path, notice: t('backend.successfully_updated_record')
     else
       set_holders
       flash[:alert] = t('backend.review_errors')
@@ -39,7 +39,7 @@ class EventsController < AdminController
 
   def destroy
     @event.destroy
-    redirect_to events_path, notice: t('backend.successfully_destroyed_record')
+    redirect_to @events_path, notice: t('backend.successfully_destroyed_record')
   end
 
   def get_title

--- a/app/controllers/uweb_access_controller.rb
+++ b/app/controllers/uweb_access_controller.rb
@@ -6,7 +6,7 @@ class UwebAccessController < ApplicationController
        @uweb_api.get_user_status(params[:clave_usuario],params[:fecha_conexion]).zero? &&
        @user = User.find_by(user_key: params[:clave_usuario])
       sign_in(:user, @user)
-      redirect_to events_path
+      redirect_to @events_path
     else
       redirect_to root_path
     end

--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -1,13 +1,41 @@
 module Admin::SidebarHelper
 
-  def active_menu(model, action=nil)
-    'active'.html_safe if params[:controller] == model && current_action?(action)
+  def active_menu(model, action=nil, shortcut = nil)
+    if active?(model, shortcut, action)
+      return 'active'.html_safe
+    end
+  end
+
+  def event_fixed_filters
+    { 'tray' => {"utf8" => "✓", "search_title" => "", "search_person" => "",
+                 "status" => ["requested", "declined"], "lobby_activity" => "1",
+                 "controller" => "events", "action" => "index"} ,
+      'events' => {"utf8" => "✓", "search_title" => "", "search_person" => "",
+                   "status" => ["accepted", "done", "canceled"],
+                   "controller" => "events", "action" => "index"} }
   end
 
   private
 
     def current_action?(action)
       action.nil? || (params[:action] == action || params[:show] == action)
+    end
+
+    def event_filters?(shortcut)
+      event_fixed_filters[shortcut] == request.env['action_dispatch.request.parameters']
+    end
+
+    def unfiltered?
+      !(event_fixed_filters.values.include? request.env['action_dispatch.request.parameters'])
+    end
+
+    def active?(model, shortcut, action)
+      # common comprobation for active link excluding events controller
+      (params[:controller] == model && current_action?(action) && shortcut.nil? && unfiltered? ) ||
+      # activaction for the two event lionks
+        event_filters?(shortcut) ||
+      # edit, and new avent activate :tray link
+       (params[:controller] == model && current_action?(action) && shortcut == 'tray' && unfiltered? )
     end
 
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -245,7 +245,7 @@
         <%= submit_tag t('backend.save_request'), :class=> "button radius success right" %>
       <% else %>
         <%= submit_tag t('backend.save'), :class=> "button radius success right" %>
-        <%= link_to t('backend.exit_without_save'), events_path, class: "button radius alert right" %>
+        <%= link_to t('backend.exit_without_save'), @events_path, class: "button radius alert right" %>
       <% end %>
     </div>
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="small-12 mt5">
   <h1><%= t('backend.edit_event')%></h1>
-  <%= link_to t('backend.back'), events_path , :class=> "button tiny radius" %>
+  <%= link_to t('backend.back'), :back , :class=> "button tiny radius" %>
 </div>
 
 <%= render :partial => 'form' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,6 +1,6 @@
 <div class="small-12 mt5">
   <h1><%= t('backend.new_event')%></h1>
-  <%= link_to t('backend.back'), events_path , :class=> "button tiny radius" %>
+  <%= link_to t('backend.back'), :back , :class=> "button tiny radius" %>
 </div>
 
 <%= render :partial => 'form' %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,46 +1,86 @@
-<div class="event-show-admin">
-  <h3><%= @event.title %></h3>
-  <%= link_to t('backend.edit'), edit_event_path(@event), :class=> "button tiny radius success" if can? :edit, @event%>
-  <%= link_to t('backend.back'), events_path , :class=> "button tiny radius" %>
-  <fieldset>
-    <legend><%= t('backend.basic_data') %></legend>
-    <p>
-      <strong><%= t('backend.holder') %></strong>
-      <%= @event.position.holder.full_name %>
-    </p>
-    <p>
-      <strong><%= t('backend.title') %></strong>
-      <%= @event.title %>
-    </p>
-    <p>
-      <strong><%= t('backend.location') %></strong>
-      <%= @event.location %>
-    </p>
-    <p>
-      <strong><%= t('backend.date') %></strong>
-      <%= I18n.l @event.scheduled, format: :short if @event.scheduled.present? %>
-    </p>
-    <p>
-      <strong><%= t('backend.description') %></strong>
-      <%= @event.description.html_safe if @event.description.present? %>
-    </p>
-  </fieldset>
-  <% if @event.user.present? %>
-  <fieldset>
-    <legend><%= t('backend.event_history_updates') %></legend>
-    <div class="row">
-      <div class="small-6 columns">
-        <p>
-          <strong><%= t('backend.event_update_user') %></strong>
-          <%= @event.user.full_name %>
-        </p>
-      </div>
-      <div class="small-6 columns">
-        <p>
-          <strong><%= t('backend.event_update_date') %></strong>
-          <%= I18n.l @event.updated_at, format: :short if @event.updated_at.present? %>
-        </p>
-      </div>
+<h3><%= @event.title %></h3>
+<%= link_to t('backend.edit'), edit_event_path(@event), :class=> "button tiny radius success" if can? :edit, @event%>
+<%= link_to t('backend.back'), :back , :class=> "button tiny radius" %>
+<fieldset>
+  <legend><%= t('backend.basic_data') %></legend>
+  <strong><%= t('backend.holder') %>:</strong>
+  <p><%= @event.position.holder.full_name %></p>
+  <strong><%= t('backend.title') %>:</strong>
+  <p><%= @event.title %></p>
+  <strong><%= t('backend.location') %>:</strong>
+  <p><%= @event.location %></p>
+  <strong><%= t('backend.date') %>:</strong>
+  <p><%= @event.scheduled.strftime(t('time.formats.short')) if @event.scheduled.present? %></p>
+  <strong><%= t('backend.description') %>:</strong>
+  <%= @event.description.html_safe if @event.description.present? %>
+</fieldset>
+<% if @event.user.present? %>
+<fieldset>
+  <legend><%= t('backend.event_history_updates') %></legend>
+  <div class="row">
+    <div class="small-6 columns"><strong><%= t('backend.event_update_user') %></strong></div>
+    <div class="small-6 columns"><strong><%= t('backend.event_update_date') %></strong></div>
+  </div>
+  <div class="row">
+    <div class="small-6 columns">
+      <p><%= @event.user.full_name %></p>
+    </div>
+    <div class="small-6 columns">
+      <p><%= @event.updated_at.strftime(t('time.formats.short')) if @event.updated_at.present? %></p>
+    </div>
+  </div>
+</fieldset>
+<% end %>
+<fieldset>
+  <legend><%= t('backend.participants') %></legend>
+  <div class="row">
+    <div class="small-4 columns">
+      <strong><%= t('backend.name') %></strong>
+    </div>
+    <div class="small-4 columns">
+      <strong><%= t('backend.position') %></strong>
+    </div>
+    <div class="small-4 columns">
+      <strong><%= t('backend.area') %></strong>
+    </div>
+  </div>
+  <% @event.participants.each do |participant| %>
+  <div class="row">
+    <div class="small-4 columns">
+      <p><%= participant.position.holder.full_name %></p>
+    </div>
+    <div class="small-4 columns">
+      <p><%= participant.position.title %></p>
+    </div>
+    <div class="small-4 columns">
+      <p><%= participant.position.area.title %></p>
+    </div>
+  </div>
+  <% end %>
+</fieldset>
+<fieldset>
+  <legend><%= t('backend.attendees') %></legend>
+  <div class="row">
+    <div class="small-4 columns">
+      <strong><%= t('backend.name') %></strong>
+    </div>
+    <div class="small-4 columns">
+      <strong><%= t('backend.position') %></strong>
+    </div>
+    <div class="small-4 columns">
+      <strong><%= t('backend.company') %></strong>
+    </div>
+  </div>
+  <% @event.attendees.each do |attendee| %>
+  <div class="row">
+    <div class="small-4 columns">
+      <p><%= attendee.name %></p>
+    </div>
+    <div class="small-4 columns">
+      <p><%= attendee.position %></p>
+    </div>
+    <div class="small-4 columns">
+      <p><%= attendee.company %></p>
     </div>
   </fieldset>
   <% end %>

--- a/app/views/layouts/_admin_sidebar.html.erb
+++ b/app/views/layouts/_admin_sidebar.html.erb
@@ -16,11 +16,23 @@
       </a>
     </li>
     <% end %>
-    <li class="<%= active_menu('events') %>">
-      <a href="<%= events_path %>">
-        <i class="fi-calendar size-18"> <%= t("backend.events")%></i>
+    <% if current_user.user? %>
+    <li class="<%= active_menu('events', nil, 'tray') %>">
+      <a href="<%= @events_path %>">
+        <i class="fi-calendar size-18">
+          <%= t("backend.event_tray") %>
+        </i>
       </a>
     </li>
+    <% else %>
+    <li class="<%= active_menu('events') %>">
+      <a href="<%= @events_path %>">
+        <i class="fi-calendar size-18">
+          <%= t("organizations.show.events_title") %>
+        </i>
+      </a>
+    </li>
+    <% end %>
     <% if current_user.admin? %>
     <li class="<%= active_menu('admin/organizations') %>">
       <a href="<%= admin_organizations_path %>">
@@ -41,6 +53,13 @@
     <li class="<%= active_menu('admin/organizations', 'show') %>">
       <a href="<%= admin_organization_path(id: current_user.organization_id) %>">
         <i class="fi-book size-18"> <%= t("backend.show_company") %></i>
+      </a>
+    </li>
+    <% end %>
+    <% if current_user.user? %>
+    <li class="<%= active_menu('events', nil, 'events') %>">
+      <a href="<%= events_path(event_fixed_filters['events']) %>">
+        <i class="fi-book size-18"> <%= t("backend.events") %></i>
       </a>
     </li>
     <% end %>
@@ -113,3 +132,4 @@
     </li>
   </ul>
 </nav>
+

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -131,7 +131,8 @@ es:
     new_event: "Nuevo evento"
     edit_event: "Editar evento"
     edit_agents: "Editar agentes"
-    add_interests: "“Editar intereses"
+    add_interests: "Editar intereses"
+    event_tray: Event tray
     edit_title_interests: "Editar áreas de interés"
     show_company: "Ver datos organización"
     activity: "Registro de Actividad"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -144,6 +144,7 @@ es:
     edit_agents: "Editar agentes"
     edit_title_interests: "Editar áreas de interés"
     add_interests: "Editar intereses"
+    event_tray: Bandeja de solicitudes
     show_company: "Ver datos lobby"
     activity: "Registro de Actividad"
     entries: "Registros"


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/agendas/issues/181

What
====
- Add 2 links to the user (:user) menu, shortcuts for filtered events

Screenshots
===========
![screenshot from 2017-12-19 13 10 35](https://user-images.githubusercontent.com/33748390/34156567-0c365748-e4be-11e7-9ded-b4d047951ce7.png)
