### PR TITLE
Search events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -138,8 +138,8 @@ class Event < ActiveRecord::Base
       self.position.holder.last_name
     end
 
-    integer :holder_id do
-      self.position.holder.id
+    integer :holder_id, multiple: true do
+      self.participants.collect(&:position).collect(&:holder_id) << self.position.holder.id
     end
 
     text :holder_position do

--- a/app/views/visitors/show.html.erb
+++ b/app/views/visitors/show.html.erb
@@ -83,7 +83,7 @@
             <% @event.attachments.each do |attachment| %>
               <% unless attachment.public == false %>
                 <p><%= link_to attachment.title, attachment.file.url,target: :blank %></p>
-                <%= attachment.description.html_safe %>
+                <%= attachment.description.html_safe if attachment.description.present? %>
               <% end %>
             <% end %>
           </div>

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -52,7 +52,6 @@ feature 'Event page' do
     expect(page).to have_content event1.title
     expect(page).to have_content event2.title
     expect(page).not_to have_content event3.title
-    # expect(page).not_to have_content event4.title
   end
 
   scenario 'search lobby activity for visitors ', :search do
@@ -66,6 +65,38 @@ feature 'Event page' do
     click_button I18n.t('backend.search.button')
 
     expect(page).to have_content "Test for check lobby_activity for visitors"
+  end
+
+  scenario "When search by holder need display his events as participant", :search do
+    position = create(:position)
+    event = create(:event, position: position, title: "Acting as participant")
+    create(:event, position: position, title: "Not involved event")
+    participant = create(:participant, event_id: event.id)
+    Event.reindex
+    Sunspot.commit
+
+    visit visitors_path
+    select "#{participant.position.holder.full_name_comma}", from: :holder
+    click_button I18n.t('backend.search.button')
+
+    expect(page).to have_content "Acting as participant"
+    expect(page).not_to have_content "Not involved event"
+  end
+
+  scenario "When search by holder need display his events as position", :search do
+    position = create(:position)
+    event1 = create(:event, position: position, title: "Acting as participant")
+    participant = create(:participant, event_id: event1.id)
+    create(:event, position: position, title: "Not involved event")
+    Event.reindex
+    Sunspot.commit
+
+    visit visitors_path
+    select "#{participant.position.holder.full_name_comma}", from: :holder
+    click_button I18n.t('backend.search.button')
+
+    expect(page).to have_content "Acting as participant"
+    expect(page).not_to have_content "Not involved event"
   end
 
   describe 'show' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #192 

# What
When search on visitors#index by "titular de agenda" the results include events that "titular de agenda" have participated as "asistente titular de agenda"

How
===
- Add to Event searcher new results by participants 

Screenshots
===========
- None

Test
====
- Add missing specs.

Deployment
==========
- As usual

Warnings
========
- None
