### PR TITLE
Check lobby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,8 +294,8 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -68,13 +68,13 @@ module Admin
                       :web, :address_type, :address, :number, :gateway, :stairs, :floor, :door,
                       :postal_code, :town, :province, :description, :registered_lobbies, :category_id,
                       :fiscal_year, :range_fund, :subvention, :contract, :denied_public_data, :denied_public_events, interest_ids: [],
-                                                                                                                     legal_representant_attributes: [:identifier, :name, :first_surname, :second_surname, :phones, :email, :_destroy],
-                                                                                                                     user_attributes: [:id, :first_name, :last_name, :role, :email, :active, :phones, :password, :password_confirmation],
-                                                                                                                     represented_entities_attributes: [:id, :identifier, :name, :first_surname, :second_surname,
-                                                                                                                                                       :from, :fiscal_year, :range_fund, :subvention, :contract, :_destroy],
-                                                                                                                     organization_interests_attributes: [:interest_ids],
-                                                                                                                     agents_attributes: [:id, :identifier, :name, :first_surname, :second_surname, :from,
-                                                                                                                                         :to, :public_assignments, :_destroy])
+                       legal_representant_attributes: [:identifier, :name, :first_surname, :second_surname, :phones, :email, :_destroy],
+                       user_attributes: [:id, :first_name, :last_name, :role, :email, :active, :phones, :password, :password_confirmation],
+                       represented_entities_attributes: [:id, :identifier, :name, :first_surname, :second_surname,
+                                                         :from, :fiscal_year, :range_fund, :subvention, :contract, :_destroy],
+                       organization_interests_attributes: [:interest_ids],
+                       agents_attributes: [:id, :identifier, :name, :first_surname, :second_surname, :from,
+                                           :to, :public_assignments, :_destroy])
       end
 
       def set_organization

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -49,7 +49,7 @@ module Admin
     def destroy
       @organization = Organization.find(params[:id])
       @organization.canceled_at = Time.zone.now
-      User.soft_destroy(@organization)
+      @organization.user.soft_deleted
 
       if @organization.save
         redirect_to admin_organizations_path,

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -29,12 +29,10 @@ class OrganizationsController < ApplicationController
 
     def search(params)
       Organization.search do
-        with(:canceled_at, nil)
         with(:entity_type_id, 2)
         with(:interest_ids, params[:interests]) if params[:interests].present?
         with(:category_id, params[:category]) if params[:category].present?
         with(:lobby_activity, true) if params[:lobby_activity].present?
-
         any do
           any do
             fulltext params[:keyword] if params[:keyword].present?
@@ -47,6 +45,7 @@ class OrganizationsController < ApplicationController
             fulltext(params[:keyword], :fields => [:agent_first_surname]) if params[:keyword].present?
             fulltext(params[:keyword], :fields => [:agent_second_surname]) if params[:keyword].present?
             with(:invalidate, false) if params[:keyword].present?
+            with(:canceled_at, nil) if params[:keyword].present?
           end
         end
         paginate page: params[:format].present? ? 1 : params[:page] || 1, per_page: params[:format].present? ? 1000 : 20
@@ -54,11 +53,7 @@ class OrganizationsController < ApplicationController
     end
 
     def set_organization
-      # if current_user.try(:admin?)
-        @organization = Organization.find(params[:id])
-      # else
-      #   @organization = Organization.validated.find(params[:id])
-      # end
+      @organization = Organization.find(params[:id])
     end
 
     def get_autocomplete_items(parameters)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,15 +4,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   layout "admin"
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  #GET /resource/sign_up
+  def new
+    debugger
+    super
+  end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+  POST /resource
+  def create
+    debugger
+    super
+  end
 
   # GET /resource/edit
   def edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,16 +5,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   layout "admin"
 
   #GET /resource/sign_up
-  def new
-    debugger
-    super
-  end
-
-  POST /resource
-  def create
-    debugger
-    super
-  end
+  # def new
+  #   super
+  # end
+  #
+  # POST /resource
+  # def create
+  #   super
+  # end
 
   # GET /resource/edit
   def edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Users::SessionsController < Devise::SessionsController
-  layout 'admin'
+  # layout 'admin'
 # before_filter :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -7,10 +7,15 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  #POST /resource/sign_in
+  def create
+    if current_user.try(:deleted_at)
+      sign_out(current_user)
+      redirect_to new_user_session_path, alert: t('devise.failure.locked')
+    else
+      super
+    end
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -35,7 +35,11 @@ module OrganizationsHelper
     if canceled_true.present?
       '<span class="label alert">Baja </span>'.html_safe
     elsif organization.invalidate.present?
-      '<span class="label warning">Inhabilitado</span>'.html_safe
+      if current_user.present? && current_user.admin?
+        '<span class="label warning">Inhabilitado</span>'.html_safe
+      else
+        '<span class="label alert">Baja </span>'.html_safe
+      end
     else
       '<span class="label success">Activo</span>'.html_safe
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,7 +22,7 @@ class Organization < ActiveRecord::Base
   accepts_nested_attributes_for :legal_representant, update_only: true, allow_destroy: true
   accepts_nested_attributes_for :user
   accepts_nested_attributes_for :represented_entities, allow_destroy: true
-  accepts_nested_attributes_for :agents, allow_destroy: true
+  accepts_nested_attributes_for :agents, allow_destroy: true, reject_if: :all_blank
 
   after_create :set_inscription_date, :set_invalidate
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,10 +63,8 @@ class User < ActiveRecord::Base
     user
   end
 
-  def self.soft_destroy(organization)
-    user = organization.user
-    user.deleted_at = Time.zone.now
-    user.save
+  def soft_deleted
+    update_attribute(:deleted_at, Time.zone.now)
   end
 
   def self.lobby?

--- a/app/views/admin/organizations/_agents_fields.html.erb
+++ b/app/views/admin/organizations/_agents_fields.html.erb
@@ -42,11 +42,12 @@
     <%= f.text_area :public_assignments, class: 'mceNoEditor' %>
     <%= form_field_errors(f, :public_assignments) %>
   </div>
-
-  <div class="small-12 columns">
-    <br />
-    <%= link_to_remove_association "Eliminar", f, class: "button tiny radius alert right" %>
-    <hr />
-  </div>
+  <% if current_user.admin? %>
+    <div class="small-12 columns">
+      <br />
+      <%= link_to_remove_association "Eliminar", f, class: "button tiny radius alert right" %>
+      <hr />
+    </div>
+  <% end %>
 
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -213,7 +213,7 @@
         </div>
       </li>
 
-      <% if !@organization.invalidate && @organization.canceled_at.blank? %>
+      <% if (!@organization.invalidate && @organization.canceled_at.blank?) || current_user.try(:admin?) %>
         <li class="accordion-navigation active">
           <div class="accordion-title">
             <%= t('organizations.show.agents_title') %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -213,32 +213,34 @@
         </div>
       </li>
 
-      <li class="accordion-navigation active">
-        <div class="accordion-title">
-          <%= t('organizations.show.agents_title') %>
-          <span class="fa accordion-icon"></span>
-        </div>
-          <div class="content active">
-            <% if @organization.agents.present? %>
-              <% @organization.agents.each do |agent| %>
-                <p>
-                  <strong><%= t('organizations.show.agents_fullname') %></strong>
-                  <%= agent.fullname %>
-                </p>
-                <p><strong><%= t('organizations.show.agents_from') %></strong>
-                  <%= I18n.l agent.from if agent.from? %>
-                </p>
-                <% if agent.to.present? %>
-                  <p><strong><%= t('organizations.show.agents_to') %></strong>
-                    <%= I18n.l agent.to if agent.to.present? %>
+      <% if !@organization.invalidate && @organization.canceled_at.blank? %>
+        <li class="accordion-navigation active">
+          <div class="accordion-title">
+            <%= t('organizations.show.agents_title') %>
+            <span class="fa accordion-icon"></span>
+          </div>
+            <div class="content active">
+              <% if @organization.agents.present? %>
+                <% @organization.agents.each do |agent| %>
+                  <p>
+                    <strong><%= t('organizations.show.agents_fullname') %></strong>
+                    <%= agent.fullname %>
                   </p>
+                  <p><strong><%= t('organizations.show.agents_from') %></strong>
+                    <%= I18n.l agent.from if agent.from? %>
+                  </p>
+                  <% if agent.to.present? %>
+                    <p><strong><%= t('organizations.show.agents_to') %></strong>
+                      <%= I18n.l agent.to if agent.to.present? %>
+                    </p>
+                  <% end %>
                 <% end %>
+              <% else %>
+                <%= t('organizations.show.no_results') %>
               <% end %>
-            <% else %>
-              <%= t('organizations.show.no_results') %>
-            <% end %>
-        </div>
-      </li>
+          </div>
+        </li>
+      <% end %>
 
       <li class="accordion-navigation active">
         <div class="accordion-title">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   # Admin
   get "/admin", to: 'events#index', as: 'admin'
 
-  devise_for :users, controllers: { session: "users/sessions" }
+  devise_for :users, controllers: { sessions: "users/sessions" }
   get 'admin/edit_password', to: 'admin/passwords#edit', as: 'edit_password'
   match 'admin/update_password', to: 'admin/passwords#update', as: 'update_password', via: [:patch, :put]
 

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1062,6 +1062,18 @@ feature 'Organization' do
       expect(page).to have_content 'no puede estar en blanco'
     end
 
+    scenario 'Can not destroy agents', :js do
+      visit admin_path
+
+      click_link I18n.t("backend.edit_agents")
+      click_link I18n.t('backend.agents.add_association')
+
+      within '#nested-agents' do
+        expect(page).not_to have_content 'Eliminar'
+      end
+    end
+
+
     scenario 'Can add interests' do
       visit admin_path
 

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -959,6 +959,27 @@ feature 'Organization' do
         end
       end
 
+      scenario "Should display canceled organization and display agent info" do
+        organization = create(:organization, canceled_at: Date.current)
+        agent = create(:agent, organization: organization)
+
+        visit organization_path(organization)
+
+        expect(page).to have_content organization.name
+        expect(page).to have_content agent.fullname
+      end
+
+      scenario "Should display invalidate organization and displday agent info" do
+        organization = create(:organization)
+        agent = create(:agent, organization: organization)
+        organization.update(invalidate: true)
+
+        visit organization_path(organization)
+
+        expect(page).to have_content organization.name
+        expect(page).to have_content agent.fullname
+      end
+
     end
 
   end

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -930,6 +930,37 @@ feature 'Organization' do
 
     end
 
+    describe "Show" do
+
+      describe "organization status" do
+        scenario "Should display organization status active" do
+          organization = create(:organization)
+
+          visit organization_path(organization)
+
+          expect(page).to have_content "Estado Activo"
+        end
+
+        scenario "Should display organization canceled" do
+          organization = create(:organization, canceled_at: Date.current)
+
+          visit organization_path(organization)
+
+          expect(page).to have_content "Estado Baja"
+        end
+
+        scenario "Should display organization invalidate" do
+          organization = create(:organization)
+          organization.update(invalidate: true)
+
+          visit organization_path(organization)
+
+          expect(page).to have_content "Estado Inhabilitado"
+        end
+      end
+
+    end
+
   end
 
   describe "Manager" do

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -27,7 +27,7 @@ feature 'Organizations page' do
       visit organizations_path
 
       expect(page).to have_content organization1.name
-      expect(page).not_to have_content organization2.name
+      expect(page).to have_content organization2.name
     end
 
     scenario "Should show invalidated organizations", :search do
@@ -354,7 +354,7 @@ feature 'Organizations page' do
           Organization.reindex
           visit organizations_path
 
-          expect(page).not_to have_content(@org1.name)
+          expect(page).to have_content(@org1.name)
 
           fill_in :keyword, with: "Maria"
           click_button(I18n.t('main.form.search'))

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -31,4 +31,12 @@ feature 'Sign in', :devise do
     expect(page).to have_link("Regístrate", href: "https://sede.madrid.es")
   end
 
+  scenario 'should not allow soft deleted user' do
+    user = FactoryGirl.create(:user, deleted_at: DateTime.current)
+
+    signin(user.email, user.password)
+
+    expect(page).to have_content "Tu cuenta ha sido bloqueada."
+  end
+
 end


### PR DESCRIPTION
What
====
- Avoid user soft delete sign in
- Display organizations invalid or canceled on index. 
- Only can search by agents when invalidate eq false and not canceled. 
- When organization is canceled or invalidate can display his show page but without agents.
- When organization is canceled or invalidate an user admin can display his show page with agents.

Screenshots
===========
- None

Test
====
- Add missing specs

Deployment
==========
- As usual

Warnings
========
- None
