### PR TITLE
Lock yard dependency to patched version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yard (0.8.7.6)
+    yard (~> 0.9.11)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
What
====
Solve potential security vulnerability of current 'yard' gem version. 

'yard' gem is a 'jazz_hands' gem dependency.

How
===
Update yard version to github suggested one.

Screenshots
===========
![captura de pantalla 2017-12-21 a las 23 12 52](https://user-images.githubusercontent.com/15726/34277077-9be459f2-e6a4-11e7-89ec-1ddaf3aff76c.png)
