### PR TITLE
Add new rake task add_registered_lobbies

### DIFF
--- a/lib/tasks/organizations.rake
+++ b/lib/tasks/organizations.rake
@@ -45,4 +45,18 @@ namespace :organizations do
     end
   end
 
+  desc "Add new registered_lobbies to database if they do not exists"
+  task :add_registered_lobbies => :environment do
+    registered_lobbies = ['no_record',
+                          'generalitat_catalunya',
+                          'cnmc',
+                          'europe_union',
+                          'others']
+
+
+    registered_lobbies.each do |name|
+      RegisteredLobby.find_or_create_by(name: name)
+    end
+  end
+  
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #221 

What
====
- Add values for Registered lobbies.

How
===
- Create a rake task to import all registered lobbies.

Screenshots
===========
- None

Test
====
- None

Deployment
==========
- Execute rake organizations:add_registered_lobbies

Warnings
========
- None
