### PR TITLE
Add attachments to organizations

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -75,6 +75,7 @@ module Admin
                       represented_entities_attributes: [:id, :identifier, :name, :first_surname, :second_surname,
                                                         :from, :fiscal_year, :range_fund, :subvention, :contract, :_destroy],
                       organization_interests_attributes: [:interest_ids],
+                      attachments_attributes: [:id, :file, :_destroy],
                       interest_ids: [], registered_lobby_ids: [])
       end
 

--- a/app/helpers/admin/organizations_helper.rb
+++ b/app/helpers/admin/organizations_helper.rb
@@ -12,5 +12,9 @@ module Admin
     def show_partial?(partial)
       params[:show] ? params[:show] == partial && current_user.lobby? : false
     end
+
+    def organization_attachments_download_dropdown_id(organization)
+      "organization_#{organization.id}_attachments_dropdown"
+    end
   end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -21,6 +21,7 @@ class Attachment < ActiveRecord::Base
 
   belongs_to :event
   belongs_to :agent
+  belongs_to :organization
 
   after_validation :cleanup_paperclip_duplicate_errors
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,6 +18,7 @@ class Organization < ActiveRecord::Base
   has_many :events
   has_many :organization_registered_lobbies, dependent: :destroy
   has_many :registered_lobbies, through: :organization_registered_lobbies, dependent: :destroy
+  has_many :attachments, dependent: :destroy
   has_one :comunication_representant, dependent: :destroy
   has_one :user, dependent: :destroy
   has_one :legal_representant, dependent: :destroy
@@ -27,6 +28,7 @@ class Organization < ActiveRecord::Base
   accepts_nested_attributes_for :user
   accepts_nested_attributes_for :represented_entities, allow_destroy: true
   accepts_nested_attributes_for :registered_lobbies, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :attachments, allow_destroy: true, reject_if: :all_blank
 
   before_create :set_inscription_date
   before_validation :invalidate_organization, :validate_organization

--- a/app/views/admin/organizations/_attachment_fields.html.erb
+++ b/app/views/admin/organizations/_attachment_fields.html.erb
@@ -1,0 +1,16 @@
+<div class="nested-fields small-12 columns">
+  <div class="row">
+    <div class="small-2columns left">
+      <%= f.hidden_field :_destroy %>
+      <% if f.object.file.present? && f.object.errors.empty? %>
+        <%= link_to t('backend.open_file'), f.object.file.url %>
+      <% else %>
+        <%= f.file_field :file, class: "attachment" %>
+      <% end %>
+    </div>
+    <div class="small-3 columns left">
+      <%= link_to_remove_association t('backend.organization.remove_attachment'), f,
+                                     class: "button tiny radius alert right" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/organizations/_attachments.html.erb
+++ b/app/views/admin/organizations/_attachments.html.erb
@@ -1,0 +1,21 @@
+<fieldset>
+  <legend><%= t('backend.attachments') %></legend>
+  <div class="row">
+    <div id="nested-attachments">
+      <%= f.fields_for :attachments do |attachments_builder| %>
+        <%= render 'attachment_fields', f: attachments_builder %>
+      <% end %>
+    </div>
+    <div class="small-12 columns">
+      <%= link_to_add_association t('backend.organization.add_attachment'), f,
+                                :attachments,
+                                partial: "attachment_fields",
+                                id: "attachments_link",
+                                class: "button tiny radius info",
+                                data: {
+                                  association_insertion_node: "#nested-attachments",
+                                  association_insertion_method: "append"
+                                } %>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/admin/organizations/_form.html.erb
+++ b/app/views/admin/organizations/_form.html.erb
@@ -10,6 +10,7 @@
   <%= render 'interests', f: f %>
   <%= render 'agents', organization: @organization %>
   <%= render 'terms', f: f %>
+  <%= render 'attachments', f: f %>
   <%= render 'invalidate', f: f %>
 
   <div class="small-4 medium-3 large-2 column">

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -56,6 +56,28 @@
                       title: t('backend.delete') do %>
             <i class="step fi-page-delete size-24"></i>
           <% end if can? :destroy, organization %>
+
+          <% if organization.attachments.any? %>
+            <%= link_to "#", title: t('backend.attachments_download'),
+                        class: "organization-attachments-dropdown-link",
+                        data: { dropdown: "#{organization_attachments_download_dropdown_id(organization)}" },
+                        aria: { controls: "#{organization_attachments_download_dropdown_id(organization)}" } do %>
+              <i class="step fi-archive size-24"></i>
+            <% end %>
+
+            <ul id="<%= organization_attachments_download_dropdown_id(organization) %>"
+                class="organization-attachments-dropdown f-dropdown"
+                data-dropdown-content aria-hidden="true" tabindex="-1">
+              <% organization.attachments.each do |attachment| %>
+                <li>
+                  <%= link_to attachment.file.url, target: :_blank do %>
+                    <i class="step fi-archive size-24"></i>
+                    <%= attachment.file.original_filename %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </td>
       </tr>
       <% end %>

--- a/config/locales/organizations.es.yml
+++ b/config/locales/organizations.es.yml
@@ -87,6 +87,10 @@ es:
     placeholder:
       phones: "Puede añadir más de un teléfono"
 
+    organization:
+      add_attachment: Añadir archivo adjunto
+      remove_attachment: Eliminar archivo adjunto
+
     identifying_data:
       title_fieldset: "Datos identificativos"
       identifier: "DNI/NIF/NIE/Pasaporte"

--- a/db/migrate/20171226135403_add_organization_id_to_attachments.rb
+++ b/db/migrate/20171226135403_add_organization_id_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToAttachments < ActiveRecord::Migration
+  def change
+    add_reference :attachments, :organization, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171223192052) do
+ActiveRecord::Schema.define(version: 20171226135403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,10 +74,12 @@ ActiveRecord::Schema.define(version: 20171223192052) do
     t.text     "description"
     t.boolean  "public"
     t.integer  "agent_id"
+    t.integer  "organization_id"
   end
 
   add_index "attachments", ["agent_id"], name: "index_attachments_on_agent_id", using: :btree
   add_index "attachments", ["event_id"], name: "index_attachments_on_event_id", using: :btree
+  add_index "attachments", ["organization_id"], name: "index_attachments_on_organization_id", using: :btree
 
   create_table "attendees", force: :cascade do |t|
     t.string   "name"
@@ -350,6 +352,7 @@ ActiveRecord::Schema.define(version: 20171223192052) do
 
   add_foreign_key "agents", "organizations"
   add_foreign_key "attachments", "events"
+  add_foreign_key "attachments", "organizations"
   add_foreign_key "attendees", "events"
   add_foreign_key "event_agents", "events"
   add_foreign_key "event_represented_entities", "events"

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -928,7 +928,7 @@ feature 'Organization' do
 
           scenario 'Should remove destroyed attachments', :js do
             organization = create(:organization)
-            attachment = create(:attachment, organization: organization)
+            create(:attachment, organization: organization)
             visit edit_admin_organization_path(organization)
 
             click_link "Eliminar archivo adjunto"

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1,9 +1,10 @@
 feature 'Organization' do
 
   describe 'User admin' do
+
     background do
       user_admin = create(:user, :admin)
-      signin(user_admin.email, user_admin.password)
+      login_as user_admin
     end
 
     scenario 'Visit admin page and display organization button on sidebar' do
@@ -14,9 +15,7 @@ feature 'Organization' do
 
     describe "Index" do
 
-      background do
-        3.times { create(:organization) }
-      end
+      let!(:organizations) { create_list(:organization, 3) }
 
       describe "Search form", :search do
 
@@ -105,6 +104,20 @@ feature 'Organization' do
 
       end
 
+      scenario "Should display attachments downloads menu dropdown when organization has any attachment", :js, :search do
+        organization = organizations.first
+        create(:attachment, organization: organization)
+        Organization.reindex
+        visit admin_organizations_path
+
+        expect(page).to have_selector ".organization-attachments-dropdown", visible: false
+        within "#organization_#{organization.id}" do
+          find(".organization-attachments-dropdown-link").click
+
+          expect(page).to have_selector ".organization-attachments-dropdown", visible: true
+        end
+      end
+
       scenario 'visit admin page and organization button render organization index', :search do
         Organization.reindex
         visit admin_path
@@ -170,19 +183,38 @@ feature 'Organization' do
         expect(page).to have_button "Guardar"
       end
 
-      scenario 'Should not display agents link new organization records' do
-        visit new_admin_organization_path
+      describe "Agents" do
+        scenario 'Should not display agents link new organization records' do
+          visit new_admin_organization_path
 
-        expect(page).not_to have_content "Añadir Agentes"
+          expect(page).not_to have_content "Añadir Agentes"
+        end
+
+        scenario 'Should display agents notice for new organization records' do
+          visit new_admin_organization_path
+
+          expect(page).to have_content "Podrás crear agentes una vez hayas creado "   \
+                                       "el lobby. Completa el formulario y pulsa "    \
+                                       "'Guardar', una vez almacenado se habilitará " \
+                                       "la opción para añadir agentes."
+        end
       end
 
-      scenario 'Should display agents notice for new organization records' do
-        visit new_admin_organization_path
+      describe "Documents" do
+        scenario 'Should display add attachment link' do
+          visit new_admin_organization_path
 
-        expect(page).to have_content "Podrás crear agentes una vez hayas creado "   \
-                                     "el lobby. Completa el formulario y pulsa "    \
-                                     "'Guardar', una vez almacenado se habilitará " \
-                                     "la opción para añadir agentes."
+          expect(page).to have_content "Archivos adjuntos"
+          expect(page).to have_link "Añadir archivo adjunto"
+        end
+
+        scenario 'Should add new attachment file attribute after click "Añadir archivo adjunto" link', :js do
+          visit new_admin_organization_path
+
+          expect(page).not_to have_selector "input[type=file]"
+          click_link "Añadir archivo adjunto"
+          expect(page).to have_selector "input[type=file]"
+        end
       end
     end
 
@@ -355,6 +387,7 @@ feature 'Organization' do
         expect(page).to have_content "European Country"
         expect(page).to have_content "Local Lobby"
       end
+
       describe "Nested fields" do
 
         describe "Legal Representant" do
@@ -502,6 +535,28 @@ feature 'Organization' do
           end
         end
 
+        describe "Documents" do
+          scenario 'Create organization with valid document', :js do
+            category = create(:category)
+            visit new_admin_organization_path
+            fill_in :organization_name, with: "organization name"
+            select category.name, from: :organization_category_id
+            fill_in :organization_user_attributes_first_name, with: "user first name"
+            fill_in :organization_user_attributes_last_name, with: "user last name"
+            fill_in :organization_user_attributes_email, with: "user@email.com"
+            fill_in :organization_user_attributes_password, with: "password"
+            fill_in :organization_user_attributes_password_confirmation, with: "password"
+
+            click_link "Añadir archivo adjunto"
+            within "#nested-attachments" do
+              attach_file find("input[type='file']")[:id], "spec/fixtures/dummy.pdf"
+            end
+            click_button "Guardar"
+
+            expect(page).to have_content "Registro creado correctamente"
+            expect(Organization.last.attachments.count).to eq(1)
+          end
+        end
       end
 
       scenario "Shouldn't show invalidate button" do
@@ -849,6 +904,38 @@ feature 'Organization' do
             organization.reload
             expect(page).to have_content "Registro actualizado correctamente"
             expect(organization.represented_entities).to eq []
+          end
+
+        end
+
+        describe "Documents" do
+          scenario 'Should display add attachment link' do
+            organization = create(:organization)
+            visit edit_admin_organization_path(organization)
+
+            expect(page).to have_content "Archivos adjuntos"
+            expect(page).to have_link "Añadir archivo adjunto"
+          end
+
+          scenario 'Should add new attachment file attribute after click "Añadir archivo adjunto" link', :js do
+            organization = create(:organization)
+            visit edit_admin_organization_path(organization)
+
+            expect(page).not_to have_selector "input[type=file]"
+            click_link "Añadir archivo adjunto"
+            expect(page).to have_selector "input[type=file]"
+          end
+
+          scenario 'Should remove destroyed attachments', :js do
+            organization = create(:organization)
+            attachment = create(:attachment, organization: organization)
+            visit edit_admin_organization_path(organization)
+
+            click_link "Eliminar archivo adjunto"
+            click_on "Guardar"
+            visit edit_admin_organization_path(organization)
+
+            expect(page).not_to have_link "Eliminar archivo adjunto"
           end
 
         end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #216 

What
====
Allow organizations to have many attachments.

How
===
Adding foreign key to attachment model called :organization_id.
Adding nested attachment fields to organization form.

Screenshots
===========
![captura de pantalla 2017-12-26 a las 19 51 16](https://user-images.githubusercontent.com/15726/34362713-3685778c-ea76-11e7-9f36-4a977ca30fd4.png)
![captura de pantalla 2017-12-26 a las 19 50 57](https://user-images.githubusercontent.com/15726/34362714-36b65e24-ea76-11e7-93cc-f92a32b51383.png)
![captura de pantalla 2017-12-26 a las 19 50 49](https://user-images.githubusercontent.com/15726/34362715-36e4defc-ea76-11e7-88e1-30e5b16fabf6.png)
![captura de pantalla 2017-12-26 a las 19 50 42](https://user-images.githubusercontent.com/15726/34362716-3713ff66-ea76-11e7-81d9-308d82fd1dd7.png)
![captura de pantalla 2017-12-26 a las 19 50 31](https://user-images.githubusercontent.com/15726/34362717-37456042-ea76-11e7-933e-f88088b5bf10.png)
![captura de pantalla 2017-12-26 a las 19 50 21](https://user-images.githubusercontent.com/15726/34362718-3770ef46-ea76-11e7-8309-f75718449edf.png)

Test
====
Test coverage increased to grant nested attachments behaviour.

Deployment
==========
As usual

Warnings
========
None
