### PR TITLE
Set lobby_activity to false on old events update task.

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -10,18 +10,13 @@ namespace :events do
 
   desc "Update old event status to done or accepted"
   task update_old_event_status: :environment do
-    puts "Starting conversion of old events without status"
-    Event.where("status is ?", nil).each do |event|
-      if event.scheduled.present?
-        if event.scheduled > Time.zone.today
-          event.update(status: :accepted)
-          puts "Event updated to accepted"
-        else
-          event.update(status: :done)
-          puts "Event updated to done"
-        end
-      end
-    end
+    puts "Starting conversion of old events without status to accepted"
+    Event.where("status is ? AND scheduled > ?", nil, Time.zone.today).update_all(status: :accepted, lobby_activity: false)
+    puts "Finished conversion of old events without status to accepted"
+
+    puts "Starting conversion of old events without status to done"
+    Event.where("status is ? AND scheduled <= ?", nil, Time.zone.today).update_all(status: :done, lobby_activity: false)
+    puts "Finished conversion of old events without status to done"
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related PR's:** #222 

What
====
Old events should have a value [true|false] to pass model validations.

Update old version events setting lobby_activity to false.