### PR TITLE
Add welcome email when create organization. Add specs

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -22,6 +22,7 @@ module Admin
       @organization = Organization.new(organization_params)
       @organization.entity_type = 'lobby'
       if @organization.save
+        UserMailer.welcome(@organization.user).deliver_now
         redirect_to admin_organizations_path, notice: t('backend.successfully_created_record')
       else
         flash[:alert] = t('backend.review_errors')

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -231,6 +231,7 @@ feature 'Organization' do
       end
 
       scenario 'Visit new admin organization page and create organization with the minimum permitted fields' do
+        ActionMailer::Base.deliveries = []
         category = create(:category)
         visit new_admin_organization_path
 
@@ -244,6 +245,7 @@ feature 'Organization' do
         click_button "Guardar"
 
         expect(page).to have_content "Registro creado correctamente"
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
       end
 
       scenario 'Should create organization with data fields' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,35 @@
 require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe "welcome" do
+
+    before do
+      @organization = create(:organization)
+    end
+
+    let!(:mail)      { UserMailer.welcome(@organization.user) }
+
+    it "should send from example" do
+      expect(mail.from).to eq([ "from@example.com"])
+    end
+
+    it "should send to new user" do
+      expect(mail.to).to eq([@organization.user.email])
+    end
+
+    it "should contain welcome subject" do
+      expect(mail.subject).to eq  I18n.t('mailers.welcome_organization.subject')
+    end
+
+    it "should contain welcome body" do
+      expect(mail.body).to have_content I18n.t('mailers.welcome_organization.welcome', name: @organization.user.name)
+      expect(mail.body).to have_content I18n.t('mailers.welcome_organization.text1')
+      expect(mail.body).to have_content I18n.t('mailers.welcome_organization.text2', email: @organization.user.email, password: @organization.user.password)
+      expect(mail.body).to have_content I18n.t('mailers.welcome_organization.thanks')
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #237 

# What
When create organization need send mail to user organization with his account and his password.

# How
Send welcome user mailer to new user when create organization.

Screenshots
===========
- None

Test
====
- Add mailer specs. Add count mailer when create organization.

Deployment
==========
- As usual.

Warnings
========
- None
