### PR TITLE
Fix url generation for https

### DIFF
--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -8,18 +8,18 @@ module OrganizationsHelper
   end
 
   def organization_represented_entities_url_pattern(format)
-    url = organization_represented_entities_url(organization_id: 1, format: format, protocol: protocol_for_urls)
-    url.gsub('1', 'organization_id')
+    url = organization_represented_entities_url(organization_id: 999, format: format, protocol: protocol_for_urls)
+    url.gsub('999', 'organization_id')
   end
 
   def organization_agents_url_pattern(format)
-    url = organization_agents_url(organization_id: 1, format: format, protocol: protocol_for_urls)
-    url.gsub('1', 'organization_id')
+    url = organization_agents_url(organization_id: 999, format: format, protocol: protocol_for_urls)
+    url.gsub('999', 'organization_id')
   end
 
   def organization_category_url_pattern
-    url = organization_url(id: 1, format: :json, protocol: protocol_for_urls)
-    url.gsub('1', 'organization_id')
+    url = organization_url(id: 999, format: :json, protocol: protocol_for_urls)
+    url.gsub('999', 'organization_id')
   end
 
   def protocol_for_urls

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -8,21 +8,18 @@ module OrganizationsHelper
   end
 
   def organization_represented_entities_url_pattern(format)
-    rooturl = root_url
     url = organization_represented_entities_url(organization_id: 1, format: format, protocol: protocol_for_urls)
-    "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
+    url.gsub('1', 'organization_id')
   end
 
   def organization_agents_url_pattern(format)
-    rooturl = root_url
     url = organization_agents_url(organization_id: 1, format: format, protocol: protocol_for_urls)
-    "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
+    url.gsub('1', 'organization_id')
   end
 
   def organization_category_url_pattern
-    rooturl = root_url
     url = organization_url(id: 1, format: :json, protocol: protocol_for_urls)
-    "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
+    url.gsub('1', 'organization_id')
   end
 
   def protocol_for_urls

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -9,20 +9,28 @@ module OrganizationsHelper
 
   def organization_represented_entities_url_pattern(format)
     rooturl = root_url
-    url = organization_represented_entities_url(organization_id: 1, format: format)
+    url = organization_represented_entities_url(organization_id: 1, format: format, protocol: protocol_for_urls)
     "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
   end
 
   def organization_agents_url_pattern(format)
     rooturl = root_url
-    url = organization_agents_url(organization_id: 1, format: format)
+    url = organization_agents_url(organization_id: 1, format: format, protocol: protocol_for_urls)
     "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
   end
 
   def organization_category_url_pattern
     rooturl = root_url
-    url = organization_url(id: 1, format: :json)
+    url = organization_url(id: 1, format: :json, protocol: protocol_for_urls)
     "#{rooturl}#{url.gsub(rooturl, '').gsub('1', 'organization_id')}"
+  end
+
+  def protocol_for_urls
+    if Rails.env.development? || Rails.env.test?
+      :http
+    else
+      :https
+    end
   end
 
   def search_by_filter?

--- a/app/views/events/_event_represented_entities.html.erb
+++ b/app/views/events/_event_represented_entities.html.erb
@@ -1,4 +1,4 @@
-<div class="row represented-entities-block" data-new-url="<%= organization_represented_entities_url_pattern(format: :json) %>">
+<div class="row represented-entities-block" data-new-url="<%= organization_represented_entities_url_pattern(:json) %>">
   <div class="small-10 columns">Empresas Representadas</div>
   <div class="small-2 columns"></div>
 


### PR DESCRIPTION
What
====
- Generates internal json calls for autocomplete using the https protocol

Why
===
- The autocomplete when creating an event was throwing a Mixed Content exception, as the page is loaded with https but this url was making an http call

How
===
- Using the protocol param for url generation

Screenshots
===========
- Internal json call using https
<img width="917" alt="https json call" src="https://user-images.githubusercontent.com/4169/34393262-897668ee-eb51-11e7-9437-124966af82ba.png">

Test
====
- Not needed

Deployment
==========
- As usual

Warnings
========
- None
