### PR TITLE
Render event attachment description only when is present

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -166,7 +166,7 @@
       <div class="small-12 columns">
         <p>
           <strong><%= t('backend.attachments_description') %></strong>
-          <%= attachment.description.html_safe %>
+          <%= attachment.description.html_safe if attachment.description.present? %>
         </p>
       </div>
       <div class="small-12 columns">


### PR DESCRIPTION
Where
=====
* **Related Issue:** #255 

What
====
Render attachment description only when is present on user show page.

Description attribute from event attachments is not mandatory so we cannot apply always html_safe.

How
===
Adding simple condition!