### PR TITLE
Change default sender for Devise Mailer

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'default from: "no-reply@madrid.es"'
+  config.mailer_sender = 'no-reply@madrid.es'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/features/users/passwords_spec.rb
+++ b/spec/features/users/passwords_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 describe "Passwords" do
 
-  before { Warden.test_reset! }
-
   describe "New" do
 
     let!(:user) { create(:user) }

--- a/spec/features/users/passwords_spec.rb
+++ b/spec/features/users/passwords_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe "Passwords" do
 
+  before { Warden.test_reset! }
+
   describe "New" do
 
     let!(:user) { create(:user) }

--- a/spec/features/users/sessions_spec.rb
+++ b/spec/features/users/sessions_spec.rb
@@ -1,7 +1,5 @@
 feature 'Sessions', :devise do
 
-  after { Warden.test_reset! }
-  
   describe 'Create' do
 
     scenario 'user cannot sign in if not registered' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,5 +57,8 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-end
 
+  config.after :each do
+    Warden.test_reset!
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #304

What
====
Fix devise mailer configuration. 

How
===
Changing mailer_sender email at devise initializer.

Screenshots
===========
Not needed

Test
====
None

Deployment
==========
As usual

Warnings
========
None
