### PR TITLE
fixed rss and atom routes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@
     <%= javascript_include_tag 'application' %>
     <%= javascript_include_tag "vendor/modernizr" %>
     <%= csrf_meta_tags %>
-    <%= auto_discovery_link_tag :atom, root_path(format: :atom) %>
-    <%= auto_discovery_link_tag :rss, root_path(format: :rss) %>
+    <%= auto_discovery_link_tag :atom, visitors_path(format: :atom), id: 'atom_link' %>
+    <%= auto_discovery_link_tag :rss, visitors_path(format: :rss), id: 'rss_link' %>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/app/views/layouts/faq.html.erb
+++ b/app/views/layouts/faq.html.erb
@@ -10,8 +10,8 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
     <%= csrf_meta_tags %>
-    <%= auto_discovery_link_tag :atom, root_path(format: :atom) %>
-    <%= auto_discovery_link_tag :rss, root_path(format: :rss) %>
+    <%= auto_discovery_link_tag :atom, visitors_path(format: :atom), id: 'atom_link' %>
+    <%= auto_discovery_link_tag :rss, visitors_path(format: :rss), id: 'rss_link' %>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -12,7 +12,7 @@
 
     <div class="small-12 columns tools">
       <div class="mb20">
-        <%= t('main.get_updates')%><a href="<%= current_url(:format=>:atom)%>"><span class="icon icon__feed"></span> feed</a>
+        <%= t('main.get_updates')%><a id= "atom_link" href="<%= current_url(:format=>:atom)%>"><span class="icon icon__feed"></span> feed</a>
         <%= export_link(current_url(format: :csv)) %>
       </div>
 

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -61,6 +61,27 @@ feature 'Event page' do
     expect(page).not_to have_content event6.title
   end
 
+  scenario 'show events on atom feed', :search do
+    event1 = create(:event, published_at: Time.zone.yesterday, title: 'event1')
+
+    event1.update(status: :accepted)
+
+    Event.reindex
+    Sunspot.commit
+
+    visit visitors_path
+
+    expect(page.html).to include('<link rel="alternate" type="application/atom+xml" title="ATOM" href="/visitors.atom" />')
+    expect(page.html).to include('<link rel="alternate" type="application/rss+xml" title="RSS" href="/visitors.rss" />')
+
+    page.find('#atom_link').click
+
+    expect(page).to have_content event1.title
+    expect(page).to have_content event1.description
+    expect(page).to have_content event1.scheduled
+    expect(page).to have_content event1.position.holder.full_name
+  end
+
   scenario 'search lobby activity for visitors ', :search do
     event = create(:event, title: 'Test for check lobby_activity for visitors')
     event.lobby_activity = true

--- a/spec/features/visitors/faq_spec.rb
+++ b/spec/features/visitors/faq_spec.rb
@@ -15,5 +15,8 @@ feature 'FAQ' do
 
     expect(page.body.index(@question1.title)).to be < page.body.index(@question2.title)
     expect(page.body.index(@question2.title)).to be < page.body.index(@question3.title)
+
+    expect(page.html).to include('<link rel="alternate" type="application/atom+xml" title="ATOM" href="/visitors.atom" />')
+    expect(page.html).to include('<link rel="alternate" type="application/rss+xml" title="RSS" href="/visitors.rss" />')
   end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/agendas/pull/288

What
====
- Adds corrected link for rss and atom feeds
