### PR TITLE
Redirect to visitors index when holder not found on agenda action

### DIFF
--- a/app/controllers/visitors_controller.rb
+++ b/app/controllers/visitors_controller.rb
@@ -1,6 +1,7 @@
 class VisitorsController < ApplicationController
 
   require 'ext/string'
+  before_filter :set_holder, only: [:index, :agenda]
 
   def index
     get_events
@@ -13,7 +14,6 @@ class VisitorsController < ApplicationController
   end
 
   def agenda
-    @holder = Holder.where(id: params[:holder]).first
     if @holder.blank?
       redirect_to visitors_path, alert: t('activerecord.models.holder.not_found')
     else
@@ -27,6 +27,10 @@ class VisitorsController < ApplicationController
   end
 
   private
+
+  def set_holder
+    @holder = Holder.where(id: params[:holder]).first
+  end
 
   def get_events
     @events = search(params)

--- a/app/controllers/visitors_controller.rb
+++ b/app/controllers/visitors_controller.rb
@@ -6,7 +6,6 @@ class VisitorsController < ApplicationController
     get_events
     @tree = ancestry_options(Area.unscoped.arrange(:order => 'title')) {|i| "#{'-' * i.depth} #{i.title}" }
     @holders = get_holders_by_area(params[:area])
-    get_holder
   end
 
   def show
@@ -14,9 +13,13 @@ class VisitorsController < ApplicationController
   end
 
   def agenda
-    get_holder
-    index
-    render :index
+    @holder = Holder.where(id: params[:holder]).first
+    if @holder.blank?
+      redirect_to visitors_path, alert: t('activerecord.models.holder.not_found')
+    else
+      index
+      render :index
+    end
   end
 
   def update_holders
@@ -24,13 +27,6 @@ class VisitorsController < ApplicationController
   end
 
   private
-
-  def get_holder
-    return if params[:holder].blank?
-    @holder = Holder.where(id: params[:holder]).first
-    return unless @holder.nil?
-    redirect_to :visitors, alert: t('activerecord.models.holder.not_found')
-  end
 
   def get_events
     @events = search(params)

--- a/app/controllers/visitors_controller.rb
+++ b/app/controllers/visitors_controller.rb
@@ -6,6 +6,7 @@ class VisitorsController < ApplicationController
     get_events
     @tree = ancestry_options(Area.unscoped.arrange(:order => 'title')) {|i| "#{'-' * i.depth} #{i.title}" }
     @holders = get_holders_by_area(params[:area])
+    get_holder
   end
 
   def show
@@ -13,6 +14,7 @@ class VisitorsController < ApplicationController
   end
 
   def agenda
+    get_holder
     index
     render :index
   end
@@ -22,6 +24,13 @@ class VisitorsController < ApplicationController
   end
 
   private
+
+  def get_holder
+    return if params[:holder].blank?
+    @holder = Holder.where(id: params[:holder]).first
+    return unless @holder.nil?
+    redirect_to :visitors, alert: t('activerecord.models.holder.not_found')
+  end
 
   def get_events
     @events = search(params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,7 @@
 module ApplicationHelper
 
   def show_headline(params)
-    unless params[:holder].blank?
-      holder = Holder.where(id: params[:holder]).first
-      return (render 'visitors/headline/holder', holder: holder).to_s
-    end
+    return (render 'visitors/headline/holder').to_s unless params[:holder].blank?
     return (render 'visitors/headline/search').to_s unless params[:keyword].blank?
     return (render 'visitors/headline/last').to_s
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,10 @@
 module ApplicationHelper
 
   def show_headline(params)
-    return (render 'visitors/headline/holder').to_s unless params[:holder].blank?
+    unless params[:holder].blank?
+      holder = Holder.where(id: params[:holder]).first
+      return (render 'visitors/headline/holder', holder: holder).to_s
+    end
     return (render 'visitors/headline/search').to_s unless params[:keyword].blank?
     return (render 'visitors/headline/last').to_s
   end

--- a/app/views/visitors/headline/_holder.html.erb
+++ b/app/views/visitors/headline/_holder.html.erb
@@ -2,7 +2,7 @@
   <p>
     <span class="keywords"><%= t('main.events_for') %> </span>
     <strong class="result-m mb20">
-      <%= link_to @holder.full_name, agenda_path(@holder.id, @holder.full_name.parameterize) %>
+      <%= link_to @holder.full_name, agenda_path(@holder.id, @holder.full_name.parameterize) if @holder.present? %>
     </strong>
   </p>
 </div>

--- a/app/views/visitors/headline/_holder.html.erb
+++ b/app/views/visitors/headline/_holder.html.erb
@@ -2,7 +2,7 @@
   <p>
     <span class="keywords"><%= t('main.events_for') %> </span>
     <strong class="result-m mb20">
-      <%= link_to @holder.full_name, agenda_path(@holder.id, @holder.full_name.parameterize) if @holder.present? %>
+      <%= link_to @holder.full_name, agenda_path(@holder.id, @holder.full_name.parameterize) %>
     </strong>
   </p>
 </div>

--- a/app/views/visitors/headline/_holder.html.erb
+++ b/app/views/visitors/headline/_holder.html.erb
@@ -2,11 +2,7 @@
   <p>
     <span class="keywords"><%= t('main.events_for') %> </span>
     <strong class="result-m mb20">
-      <% if holder %>
-        <%= link_to holder.full_name, agenda_path(holder.id, holder.full_name.parameterize)  %>
-      <% else %>
-        <%= t 'activerecord.models.holder.not_found' %>
-      <% end %>
+      <%= link_to @holder.full_name, agenda_path(@holder.id, @holder.full_name.parameterize) %>
     </strong>
   </p>
 </div>

--- a/app/views/visitors/headline/_holder.html.erb
+++ b/app/views/visitors/headline/_holder.html.erb
@@ -1,7 +1,12 @@
 <div class="small-12 columns mb10">
   <p>
     <span class="keywords"><%= t('main.events_for') %> </span>
-    <% holder = Holder.find(params[:holder]) %>
-    <strong class="result-m mb20"><%= link_to holder.full_name, agenda_path(holder.id, holder.full_name.parameterize)  %></strong>
+    <strong class="result-m mb20">
+      <% if holder %>
+        <%= link_to holder.full_name, agenda_path(holder.id, holder.full_name.parameterize)  %>
+      <% else %>
+        <%= t 'activerecord.models.holder.not_found' %>
+      <% end %>
+    </strong>
   </p>
 </div>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -36,6 +36,7 @@ en:
       holder:
         one: "titular de agenda"
         other: "titulares de agenda"
+        not_found: Holder not found
       attachment:
         one: "archivo adjunto"
         other: "archivos adjuntos"

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -32,6 +32,7 @@ es:
       holder:
         one: "titular de agenda"
         other: "titulares de agenda"
+        not_found: "Titular no encontrado"
       attachment:
         one: "archivo adjunto"
         other: "archivos adjuntos"

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -32,7 +32,7 @@ es:
       holder:
         one: "titular de agenda"
         other: "titulares de agenda"
-        not_found: "Titular no encontrado"
+        not_found: "No se ha encontrado el titular de agendas solicitado"
       attachment:
         one: "archivo adjunto"
         other: "archivos adjuntos"

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -107,6 +107,13 @@ feature 'Event page' do
     expect(page).not_to have_content "Not involved event"
   end
 
+  scenario 'When access using an incorrect link looking for an inexistent
+            holder, show is correctly', :search do
+    visit visitors_path(holder: 1)
+
+    expect(page).to have_content I18n.t('activerecord.models.holder.not_found')
+  end
+
   describe 'CSV export link' do
 
     scenario 'Should download a CSV file UTF-8 encoded', :search do

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -85,8 +85,6 @@ feature 'Event page' do
     visit visitors_path
     select participant.position.holder.full_name_comma, from: :holder
     click_button I18n.t('backend.search.button')
-
-    expect(page).to have_content participant.position.holder.full_name
     expect(page).to have_content "Acting as participant"
     expect(page).not_to have_content "Not involved event"
   end
@@ -107,11 +105,19 @@ feature 'Event page' do
     expect(page).not_to have_content "Not involved event"
   end
 
-  scenario 'When access using an incorrect link looking for an inexistent
-            holder, show is correctly', :search do
-    visit visitors_path(holder: 1)
+  describe "Agenda" do
+    scenario 'Should redirect to visitors#index when given holder des not exist' do
+      visit agenda_path(holder: 1, full_name: "unexisting-fullname")
 
-    expect(page).to have_content I18n.t('activerecord.models.holder.not_found')
+      expect(page).to have_content I18n.t('activerecord.models.holder.not_found')
+    end
+
+    scenario 'Should show holder agenda when given holder exists', :search do
+      holder = create(:holder)
+      visit agenda_path(holder: holder.id, full_name: holder.full_name)
+
+      expect(page).not_to have_content I18n.t('activerecord.models.holder.not_found')
+    end
   end
 
   describe 'CSV export link' do

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -106,7 +106,7 @@ feature 'Event page' do
   end
 
   describe "Agenda" do
-    scenario 'Should redirect to visitors#index when given holder des not exist' do
+    scenario 'Should redirect to visitors#index when given holder does not exist' do
       visit agenda_path(holder: 1, full_name: "unexisting-fullname")
 
       expect(page).to have_content I18n.t('activerecord.models.holder.not_found')

--- a/spec/features/visitors/event_page_spec.rb
+++ b/spec/features/visitors/event_page_spec.rb
@@ -86,6 +86,7 @@ feature 'Event page' do
     select participant.position.holder.full_name_comma, from: :holder
     click_button I18n.t('backend.search.button')
 
+    expect(page).to have_content participant.position.holder.full_name
     expect(page).to have_content "Acting as participant"
     expect(page).not_to have_content "Not involved event"
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #321, #311

What
====
Redirect request to agendas action to visitors index when given holder does not exist

How
===
Controlling holder existence at agenda action and redirecting when holder is not found.

Screenshots
===========
Not needed

Test
====
Added specs to check redirection behavior

Deployment
==========
As usual

Warnings
========
None
