### PR TITLE
Fix background styles definition on error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
-    background: #065687 url('errors_bg.jpg');
+    background: #065687 url('/errors_bg.jpg');
     color: #2E2F30;
     font-family: arial, sans-serif;
     margin: 0;

--- a/public/422.html
+++ b/public/422.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
-    background: #065687 url('errors_bg.jpg');
+    background: #065687 url('/errors_bg.jpg');
     color: #2E2F30;
     font-family: arial, sans-serif;
     margin: 0;

--- a/public/500.html
+++ b/public/500.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
-    background: #065687 url('errors_bg.jpg');
+    background: #065687 url('/errors_bg.jpg');
     color: #2E2F30;
     font-family: arial, sans-serif;
     margin: 0;


### PR DESCRIPTION
Where
=====
* **Related Issue:** #312

What
====
Fix 404, 500 and 422 pages background renderization.

![captura de pantalla 2018-01-10 a las 12 58 56](https://user-images.githubusercontent.com/15726/34772074-22f50b14-f607-11e7-8217-e64c17fca9fd.png)


How
===
Fixing CSS background image source definition.

Screenshots
===========
Not needed

Test
====
Nothing added

Deployment
==========
As usual

Warnings
========
None
