### PR TITLE
Allow manager/admin user create an event to association/federation as lobby

### DIFF
--- a/app/assets/javascripts/events.js.erb
+++ b/app/assets/javascripts/events.js.erb
@@ -299,39 +299,20 @@ function fill_autocomplete_organization_name() {
         url: $('#category-block').data('new-url').replace('organization_id', $('#event_organization_id').val())
       }).done(function( organization_info ) {
         var div_category = $('#event-category');
-        alert(organization_info[1]);
         div_category.append(organization_info[0]);
         $('#organization_entity_type').val(organization_info[1]);
-        alert($('#organization_entity_type').val() == "lobby");
         if ($('#organization_entity_type').val() == "lobby") {
-          alert("in");
           $('.represented-entities-block').show();
           $('#event_represented_entities_link').trigger('click');
           $('.agents-block').show();
           $('#event_agents_link').trigger('click');
         } else {
           $('.represented-entities-block').hide();
-          // $('#event_represented_entities_link').trigger('click');
           $('.agents-block').hide();
-          // $('#event_agents_link').trigger('click');
-        }        
+        }
       });
       $("#category-block").show();
     }
-    // alert($('#organization_entity_type').val());
-    // alert($('#organization_entity_type').val() == "lobby");
-    // if ($('#organization_entity_type').val() == "lobby") {
-    //   alert("in");
-    //   $('.represented-entities-block').show();
-    //   $('#event_represented_entities_link').trigger('click');
-    //   $('.agents-block').show();
-    //   $('#event_agents_link').trigger('click');
-    // } else {
-    //   $('.represented-entities-block').hide();
-    //   // $('#event_represented_entities_link').trigger('click');
-    //   $('.agents-block').hide();
-    //   // $('#event_agents_link').trigger('click');
-    // }
   });
 }
 

--- a/app/assets/javascripts/events.js.erb
+++ b/app/assets/javascripts/events.js.erb
@@ -55,9 +55,9 @@ $(function(){
   $.validator.addMethod("valueNotEquals", function(value, element, arg){
     agent = $("#nested-event-agents div.small-12.medium-8.columns select").val();
     delete_agents = $("#nested-event-agents .nested-fields.agents:visible").length
-    if (($("#event_lobby_activity_true").is(':checked')) && ((delete_agents == 0) || (agent == '' ||
-      typeof(agent) == 'undefined' ||
-      agent == "<%= I18n.translate('backend.event.not_available_agents')%>" )))
+    if (($("#event_lobby_activity_true").is(':checked')) &&
+       ((delete_agents == 0) || (agent == '' || typeof(agent) == 'undefined' || agent == "<%= I18n.translate('backend.event.not_available_agents')%>" )) &&
+       ($('#organization_entity_type').val() == "lobby"))
       { return false }
     else
       { return true }
@@ -297,16 +297,41 @@ function fill_autocomplete_organization_name() {
       $.ajax({
         method: "GET",
         url: $('#category-block').data('new-url').replace('organization_id', $('#event_organization_id').val())
-      }).done(function( category ) {
+      }).done(function( organization_info ) {
         var div_category = $('#event-category');
-        div_category.append(category);
+        alert(organization_info[1]);
+        div_category.append(organization_info[0]);
+        $('#organization_entity_type').val(organization_info[1]);
+        alert($('#organization_entity_type').val() == "lobby");
+        if ($('#organization_entity_type').val() == "lobby") {
+          alert("in");
+          $('.represented-entities-block').show();
+          $('#event_represented_entities_link').trigger('click');
+          $('.agents-block').show();
+          $('#event_agents_link').trigger('click');
+        } else {
+          $('.represented-entities-block').hide();
+          // $('#event_represented_entities_link').trigger('click');
+          $('.agents-block').hide();
+          // $('#event_agents_link').trigger('click');
+        }        
       });
       $("#category-block").show();
     }
-    $('.represented-entities-block').show();
-    $('#event_represented_entities_link').trigger('click');
-    $('.agents-block').show();
-    $('#event_agents_link').trigger('click');
+    // alert($('#organization_entity_type').val());
+    // alert($('#organization_entity_type').val() == "lobby");
+    // if ($('#organization_entity_type').val() == "lobby") {
+    //   alert("in");
+    //   $('.represented-entities-block').show();
+    //   $('#event_represented_entities_link').trigger('click');
+    //   $('.agents-block').show();
+    //   $('#event_agents_link').trigger('click');
+    // } else {
+    //   $('.represented-entities-block').hide();
+    //   // $('#event_represented_entities_link').trigger('click');
+    //   $('.agents-block').hide();
+    //   // $('#event_agents_link').trigger('click');
+    // }
   });
 }
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -14,7 +14,7 @@ class OrganizationsController < ApplicationController
   def show
     respond_to do |format|
       format.html
-      format.json { render json: [@organization.category.name] }
+      format.json { render json: [@organization.category.name, @organization.entity_type] }
     end
   end
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -60,7 +60,7 @@
             <hr />
           </div>
         <% end %>
-
+        <%= hidden_field_tag :organization_entity_type%>
         <%= render 'event_represented_entities', f:f %>
         <hr />
         <%= render 'event_agents', f:f %>

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -852,6 +852,7 @@ feature 'Events' do
           end
 
           scenario "When fill by js organization_name without agents display no_result_text on agents selector", :js do
+            organization = create(:organization, name: "New oganization with agents", entity_type: :lobby)
             new_position = create(:position)
             visit new_event_path
 
@@ -861,9 +862,29 @@ feature 'Events' do
             select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
             fill_in :event_published_at, with: Date.current
             choose :event_lobby_activity_true
+            choose_autocomplete :event_organization_name, with: organization.name, select: organization.name
+            sleep(0.5)
             click_button "Guardar"
 
             expect(page).to have_content I18n.translate('backend.event.event_agent_needed'), count: 1
+          end
+
+          scenario "When fill by js organization_name (Association) not display no_result_text on agents selector", :js do
+            organization = create(:organization, name: "New association", entity_type: :association)
+            new_position = create(:position)
+            visit new_event_path
+
+            fill_in :event_title, with: "Title"
+            fill_in :event_location, with: "Location"
+            fill_in :event_scheduled, with: Time.zone.now
+            select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
+            fill_in :event_published_at, with: Date.current
+            choose :event_lobby_activity_true
+            choose_autocomplete :event_organization_name, with: organization.name, select: organization.name
+
+            click_button "Guardar"
+
+            expect(page).to have_content I18n.translate('backend.event.event_agent_needed'), count: 0
           end
         end
       end


### PR DESCRIPTION
What
====
- Allow manager/admin user create an event to association/federation as lobby

How
===
- Hide and disable validations from Agents and RepresentedEntities when organizations selected is an associations/federation.

Screenshots
===========
- None

Test
====
- Add and fix specs.

Deployment
==========
- As usual

Warnings
========
- None
