### PR TITLE
Fix for `NoMethodError` exception when soft-deleting an organization

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -41,7 +41,6 @@ module Admin
       if @organization.update_attributes(organization_params)
         path = current_user.lobby? ? admin_organization_path(@organization) : admin_organizations_path
         @organization.send_update_mail
-        # @organization.send_invalidate_mail if params[:organization][:invalidate]
         redirect_to path, notice: t('backend.successfully_updated_record')
       else
         flash[:alert] = t('backend.review_errors')
@@ -52,7 +51,7 @@ module Admin
     def destroy
       @organization = Organization.find(params[:id])
       @organization.canceled_at = Time.zone.now
-      @organization.user.soft_deleted
+      @organization.user.soft_delete unless @organization.user.nil?
 
       if @organization.save
         redirect_to admin_organizations_path,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,10 @@ class User < ActiveRecord::Base
     errors.add(:base, I18n.t('backend.participants_uniqueness')) unless manages.map{|x| x.holder_id}.uniq.count == manages.to_a.count
   end
 
+  def soft_delete
+    update_attribute(:deleted_at, Time.zone.now)
+  end
+
   private
 
   def set_active
@@ -61,10 +65,6 @@ class User < ActiveRecord::Base
     user.password = SecureRandom.uuid
     user.role = role
     user
-  end
-
-  def soft_deleted
-    update_attribute(:deleted_at, Time.zone.now)
   end
 
   def self.lobby?

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1130,15 +1130,31 @@ feature 'Organization' do
 
   describe "Edit and delete (remote)" do
 
-    background do
-      user_admin = create(:user, :lobby)
-      login_as user_admin
-    end
-
     scenario 'Should show delete and edit link', :js do
+      admin = create(:user, :lobby)
+      login_as admin
       visit admin_path
 
       expect(page).to have_link I18n.t('backend.edit_delete_organization')
+    end
+
+    scenario 'destroys an organization without an associated user', :search do
+      admin = create(:user, :admin)
+      login_as admin
+
+      org = create(:organization, name: 'Github', user: nil)
+      Organization.reindex
+
+      visit admin_organizations_path
+
+      expect(page).to have_content(org.name)
+      expect(org.canceled_at.nil?).to eq(true)
+      page.click_link('', href: admin_organization_path(org))
+
+      org.reload
+
+      expect(org.canceled_at.nil?).to eq(false)
+      expect(page).to have_content(org.name)
     end
 
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #320 (This PR closes #320 once merged)

What
====
* Fixed a `NoMethodError` exception when soft deleting an organization

How
===
* `soft_delete` User method exposed as public
* Guard clause added to `Admin::Organizations` controller to avoid raising an exception if the organization does not have an user associated

Test
====
* Increased coverage

