### PR TITLE
Handle InvalidAuthenticityToken exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,12 +19,16 @@ class ApplicationController < ActionController::Base
         status = ["accepted", "done", "canceled"]
         lobby_activity = nil
       end
-      events_path({ utf8: "✓", search_title: "", search_person: "",
-                               status: status, lobby_activity: lobby_activity,
-                               controller: "events", action: "index" })
+      events_path(utf8: "✓", search_title: "", search_person: "",
+                  status: status, lobby_activity: lobby_activity,
+                  controller: "events", action: "index")
     else
       events_path
     end
+  end
+
+  def handle_unverified_request
+    events_path
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_unverified_request
-    events_path
+    new_user_session_path
   end
 
 end

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -1,0 +1,25 @@
+feature "Application" do
+
+  scenario "Try to access privileged options after closing session", :js do
+
+    ActionController::Base.allow_forgery_protection = true
+    position = create(:position)
+    user = FactoryGirl.create(:user, :admin)
+
+    login_as user
+
+    event = create(:event, user: user, title: 'Test event', position: position)
+    visit edit_event_path(event)
+
+    new_window = open_new_window
+    within_window new_window do
+      visit root_path
+      click_link I18n.t('backend.logout')
+    end
+
+    click_button I18n.t('backend.save')
+
+    expect(page).to have_content I18n.t 'devise.sessions.new.forgot_your_password'
+    expect(page).not_to have_content 'ActionController::InvalidAuthenticityToken'
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #310 

What
====
- Display an error with a invalid authenticity token 
![310](https://user-images.githubusercontent.com/34024463/35226997-240fe0fc-ff8d-11e7-9f8b-ef721ef050d4.gif)

Instructions

- Sign in
- Edit or create an event 
- Open a second tab
- Sign out in the second tab
- Return to the first tab and save the event

How
===
- Write a test that covers the bug 
- Added the method to handle the invalid token and redirect to sign in
- The test passed with the new method.

Test
====
- Added the test to verify that the error of a 'AuthenticityToken'
