### PR TITLE
Travis sunspot config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - gem install bundler
 before_script:
   - "for i in config/*.example; do cp \"$i\" \"${i/.example}\"; done"
+  - rm config/sunspot.yml # Travis generate his own solr configuration
   - bundle exec rake db:drop db:create db:migrate
 script:
   - RAILS_ENV=test bundle exec rake assets:precompile

--- a/config/sunspot.yml.example
+++ b/config/sunspot.yml.example
@@ -32,4 +32,3 @@ test:
     port: 8982
     log_level: WARNING
     path: /solr/test
-


### PR DESCRIPTION
Where
=====
* **Related Issue:** #345 

What
====
After merging #345 Travis started to fail because he wasn't able to find Solr.

How
===
Travis does not need to copy sunspot.yml.example file to be able to run specs, this was the problem indeed. Before mergin #345, sunspot.yml.example wasn't exist so Travis was able to generate his own configuration, after mergin #345, sunspot.yml was copied form exmaple file Travis started to fail because hi was not able to find solr with this configuration.

To solve this we have removed this copy from config directory so Travis use his own.

Screenshots
===========
Not needed

Test
====
Same

Deployment
==========
None

Warnings
========
None
