### PR TITLE
Deactivate organizations public page export link

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -38,7 +38,7 @@
                         class: "select-sm" %>
       </div>
       <div class="small-12 medium-3 columns export no-padding">
-        <%= export_link(current_url(format: :csv)) %>
+        <%#= export_link(current_url(format: :csv)) %>
       </div>
     </div>
     <div class="small-12 columns mb20">

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -416,6 +416,8 @@ feature 'Organizations page' do
 
     describe 'CSV export link' do
 
+      before { skip "Temporarily deactivated" }
+
       scenario 'Should download a CSV file UTF-8 encoded', :search do
         event = create(:event, published_at: Time.zone.yesterday)
         Event.reindex


### PR DESCRIPTION
What
====
Customer want changes on generated lobbies.csv files. Changes are not defined yet. In the meantime we deactivate this feature until changes are defined.

How
===
Commented link code and skipping related specs.

Screenshots
===========
Not needed

Test
====
Related specs skipped

Deployment
==========
As usual

Warnings
========
None
