### PR TITLE
Edit lobby

### DIFF
--- a/app/views/admin/organizations/_attachment_fields.html.erb
+++ b/app/views/admin/organizations/_attachment_fields.html.erb
@@ -3,7 +3,7 @@
     <div class="small-2columns left">
       <%= f.hidden_field :_destroy %>
       <% if f.object.file.present? && f.object.errors.empty? %>
-        <%= link_to t('backend.open_file'), f.object.file.url %>
+        <%= link_to  f.object.file.original_filename, f.object.file.url %>
       <% else %>
         <%= f.file_field :file, class: "attachment" %>
       <% end %>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -472,10 +472,32 @@
             </p>
           </div>
         </div>
-        <hr>
       <% end %>
+      <hr>
     <% end %>
   </fieldset>
+
+  <% if @organization.attachments.present? %>
+    <fieldset>
+      <legend>Documentos Adjuntos:</legend>
+      <% @organization.attachments.each_with_index do |attachment, index| %>
+
+        <div class="row">
+          <div class="small-12 columns">
+            <p>
+              <i><strong>Archivo <%= index + 1  %></strong></i>
+            </p>
+          </div>
+          <br />
+          <div class="small-3 medium-6 columns mb10">
+            <p>
+              <%= link_to attachment.file_file_name, attachment.file.url %>
+            </p>
+          </div>
+        </div>
+      <% end %>
+    </fieldset>
+  <% end %>
 
   <fieldset class="terms-fieldset">
     <legend><%= t('backend.terms.title_fieldset') %></legend>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -491,7 +491,7 @@
           <br />
           <div class="small-3 medium-6 columns mb10">
             <p>
-              <%= link_to attachment.file_file_name, attachment.file.url %>
+              <%= link_to attachment.file.original_filename, attachment.file.url %>
             </p>
           </div>
         </div>

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1077,7 +1077,7 @@ feature 'Organization' do
         organization = create(:organization, canceled_at: Date.current)
         agent = create(:agent, organization: organization)
 
-        visit organization_path(organization)
+        visit admin_organization_path(organization)
 
         expect(page).to have_content organization.name
         expect(page).to have_content agent.name
@@ -1091,12 +1091,21 @@ feature 'Organization' do
         organization.update(invalidated_reasons: 'test')
         organization.update(invalidated_at: Time.zone.today)
 
-        visit organization_path(organization)
+        visit admin_organization_path(organization)
 
         expect(page).to have_content organization.name
         expect(page).to have_content agent.name
         expect(page).to have_content agent.first_surname
         expect(page).to have_content agent.second_surname
+      end
+
+      scenario "Should display organizations attachments" do
+        organization = create(:organization)
+        attachment = create(:attachment, organization: organization)
+
+        visit admin_organization_path(organization)
+
+        expect(page).to have_link attachment.file_file_name
       end
 
     end

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -832,6 +832,15 @@ feature 'Organization' do
         expect(organization.lobby_term).to eq true
       end
 
+      scenario 'Display attachment name' do
+        organization = create(:organization)
+        attachment = create(:attachment, organization: organization)
+
+        visit edit_admin_organization_path(organization)
+
+        expect(page).to have_link attachment.file.original_filename
+      end
+
       describe "Nested fields" do
 
         describe "Legal Representant" do
@@ -1105,7 +1114,7 @@ feature 'Organization' do
 
         visit admin_organization_path(organization)
 
-        expect(page).to have_link attachment.file_file_name
+        expect(page).to have_link attachment.file.original_filename
       end
 
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #377 

What
====
- We want display organization attachments on organization page for admins.
- We want display organization attachment name on edit organization page.

Screenshots
===========
Admin organization page:
![captura de pantalla 2018-01-26 a las 13 46 34](https://user-images.githubusercontent.com/16189/35440365-5de43246-029f-11e8-9f69-c0f1885fbfa1.png)
Admin edit organization page:
![captura de pantalla 2018-01-26 a las 13 46 20](https://user-images.githubusercontent.com/16189/35440371-62501912-029f-11e8-9d51-d3beece88fcf.png)


Test
====
- Add specs.

Deployment
==========
- As usual

Warnings
========
- None
