### PR TITLE
Not set password when user exists. Add missing specs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ActiveRecord::Base
     user.last_name = data["APELLIDO1_USUARIO"].strip
     user.last_name += ' ' + data["APELLIDO2_USUARIO"].strip if data["APELLIDO2_USUARIO"].present?
     user.email =  data["MAIL"].blank? ? Faker::Internet.email : data["MAIL"]
-    user.password = SecureRandom.uuid
+    user.password = SecureRandom.uuid unless user.persisted?
     user.role = role
     user
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,12 +31,22 @@ describe User do
 
   it "should have be valid when created from uweb data array" do
     data = FactoryGirl.build(:uweb_user)
+
     user = User.create_from_uweb(:user, data)
-    expect(user).to be_valid
+
+    expect { user.save }.to change { User.count }.from(1).to(2)
+  end
+
+  it "should have be valid when created from uweb data array and user exists by user_key" do
+    data = FactoryGirl.build(:uweb_user)
+    @user.update(user_key: data["CLAVE_IND"] )
+
+    user = User.create_from_uweb(:user, data)
+
+    expect { user.save }.not_to change { User.count }
   end
 
   it "should not be allowed assign holder more than once to user" do
   end
 
 end
-


### PR DESCRIPTION
Where
=====
* **Related Issue:** #374 

What
====
- When import uweb process we set always password for all users.

How
===
- Only set new password when create new user. If user exists not set password

Screenshots
===========
- None

Test
====
- Add specs

Deployment
==========
- As usual.

Warnings
========
- None
