### PR TITLE
Add validate organization on create events with lobby activity

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,7 @@ class Event < ActiveRecord::Base
   validates :title, :position, presence: true
   validates_inclusion_of :lobby_activity, :in => [true, false]
   validate :participants_uniqueness, :position_not_in_participants, :role_validate_scheduled, :validate_location
+  validate :lobby_activity_with_organization, if: -> { self.lobby_activity.present? }
   validates :canceled_reasons, presence: { message: I18n.t('backend.lobby_not_allowed_neither_empty_mail') },
                                allow_blank: false, if: Proc.new { |a| !a.canceled_at.blank? }
   validates :declined_reasons, presence: { message: I18n.t('backend.lobby_not_allowed_neither_empty_mail') },
@@ -231,6 +232,11 @@ class Event < ActiveRecord::Base
     def validate_location
       return if self.user.lobby? || self.location.present?
       errors.add(:base, "Lugar no puede estar en blanco")
+    end
+
+    def lobby_activity_with_organization
+      return if self.organization.present?
+      errors.add(:base, "No ha seleccionado una organización válida")
     end
 
     def reasons_present?

--- a/spec/features/admin/events_spec.rb
+++ b/spec/features/admin/events_spec.rb
@@ -794,6 +794,23 @@ feature 'Events' do
           end
         end
 
+        scenario 'When check lobby_activity but fill invalid organization name', :js do
+          new_position = create(:position)
+          visit new_event_path
+
+          choose :event_lobby_activity_true
+          choose_autocomplete :event_organization_name, with: "invalid organization", select: "invalid organization"
+          fill_in :event_title, with: "Title"
+          fill_in :event_location, with: "Location"
+          tinymce_fill_in(:event_description, "Description")
+          fill_in :event_scheduled, with: Date.current
+          select "#{new_position.holder.full_name_comma} - #{new_position.title}", from: :event_position_id
+          fill_in :event_published_at, with: Date.current
+          click_button "Guardar"
+
+          expect(page).to have_content "No ha seleccionado una organización válida"
+        end
+
         describe "Represented entity" do
 
           scenario 'When select organization without represented_entity display organization on represented_entity selector', :js do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -44,6 +44,13 @@ describe Event do
     expect(event).not_to be_valid
   end
 
+  it "Should be invalid if event as lobby_activity without organization" do
+    event.lobby_activity = true
+    event.organization = nil
+
+    expect(event).not_to be_valid
+  end
+
   it "Should be invalid if participant are not unique" do
     event = create(:event)
     participant = create(:participant)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #392 #394 

What
====
- Avoid create event as lobby activity without organization

How
===
- Add validate on event model.

Screenshots
===========
- None

Test
====
- Add feature and model spec

Deployment
==========
- As usual

Warnings
========
- None
